### PR TITLE
Ignore $schema tag in root of MSBuild schema file

### DIFF
--- a/MonoDevelop.MSBuild/Schema/MSBuildSchema.cs
+++ b/MonoDevelop.MSBuild/Schema/MSBuildSchema.cs
@@ -73,6 +73,7 @@ namespace MonoDevelop.MSBuild.Schema
 					targets = (JObject)kv.Value;
 					break;
 				case "license":
+				case "$schema":
 					break;
 				case "intellisenseImports":
 					intellisenseImports = (JArray)kv.Value;


### PR DESCRIPTION
If the `$schema` tag is present, then Visual Studio can use it to enable better JavaScript IntelliSense. Without this change, an unknown-key warning will be emitted at runtime.