### PR TITLE
Disable the MSBuild Imports pad

### DIFF
--- a/MonoDevelop.MSBuildEditor/Properties/Manifest.addin.xml
+++ b/MonoDevelop.MSBuildEditor/Properties/Manifest.addin.xml
@@ -87,7 +87,9 @@
                 defaultHandler = "MonoDevelop.MSBuildEditor.ToggleShowPrivateSymbolsHandler" />
     </Extension>
 
+    <!--
     <Extension path="/MonoDevelop/Ide/Pads">
         <Pad class="MonoDevelop.MSBuildEditor.Pads.MSBuildImportNavigatorPad" _label="MSBuild Imports" defaultPlacement="right" />
     </Extension>
+    -->
 </ExtensionModel>


### PR DESCRIPTION
The code for this pad has not yet been ported to the new MSBuild parser. If the pad is invoked from the VSMac pads menu, an exception will be thrown and the pad will appear blank.