### PR TITLE
Deploy Mono.Cecil with the tests to keep NUnit happy

### DIFF
--- a/MonoDevelop.MSBuild.Tests/MonoDevelop.MSBuild.Tests.csproj
+++ b/MonoDevelop.MSBuild.Tests/MonoDevelop.MSBuild.Tests.csproj
@@ -16,7 +16,11 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
     <PackageReference Include="Microsoft.Build" Version="15.9.20" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" ExcludeAssets="runtime" />
-    <PackageReference Include="Mono.Cecil" Version="0.9.6" />
+    <!--
+    see https://github.com/nunit/nunit3-vs-adapter/issues/662
+    NUnit3TestAdapter forgets to declare a dependency on Cecil, so we have to bring our own.
+    -->
+    <PackageReference Include="Mono.Cecil" Version="0.9.6" ExcludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoDevelop.MSBuild.Tests/MonoDevelop.MSBuild.Tests.csproj
+++ b/MonoDevelop.MSBuild.Tests/MonoDevelop.MSBuild.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
     <PackageReference Include="Microsoft.Build" Version="15.9.20" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" ExcludeAssets="runtime" />
+    <PackageReference Include="Mono.Cecil" Version="0.9.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The test assembly deploys NUnit.Engine.dll which depends on Mono.Cecil 0.9.6

Unfortunately the NUnit3TestAdapter NuGet package neither brings Cecil nor declares a dependency on it. But it is required for NUnit.Engine.dll to function.

The simplest is to just ship Cecil with the tests to keep the NUnit.Engine.dll happy.

Some test runners may be using their own nunit.engine.dll, so for them missing cecil wouldn't be a problem.