### PR TITLE
Enable VSMac syntax classification of code

### DIFF
--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -55,7 +55,9 @@
     <EmbeddedResource Include="MSBuildStylePolicy.xml">
       <LogicalName>MSBuildStylePolicy.xml</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="Syntax\msbuild.json" />
+    <EmbeddedResource Include="Syntax\msbuild.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <AddinFile Include="Templates\Project.xft.xml" />

--- a/MonoDevelop.MSBuildEditor/Properties/Manifest.addin.xml
+++ b/MonoDevelop.MSBuildEditor/Properties/Manifest.addin.xml
@@ -76,6 +76,10 @@
     <Extension path="/MonoDevelop/Ide/Editor/Bundles">
         <Bundle resource = "MonoDevelop.MSBuildEditor.Syntax.msbuild.json" />
     </Extension>
+    
+    <Extension path="/MonoDevelop/Ide/Editor/TextMate">
+        <Repository folderPath = "Syntax" />
+    </Extension>
 
 	<Extension path="/MonoDevelop/Ide/Commands/TextEditor">
         <Command id = "MonoDevelop.MSBuildEditor.MSBuildCommands.ToggleShowPrivateSymbols"


### PR DESCRIPTION
Requires https://github.com/mono/monodevelop/pull/9033