### PR TITLE
Convert addin to SDK-style csproj

### DIFF
--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Tests/**" />
     <PackageReference Include="Microsoft.Build" Version="15.9.20" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
     <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" />

--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -24,8 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Properties\Manifest.addin.xml" />
-    <EmbeddedResource Include="Syntax\msbuild.json">
+    <EmbeddedResource Update="Syntax\msbuild.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <AddinFile Include="Templates\Project.xft.xml" />

--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>MonoDevelop.MSBuildEditor</RootNamespace>
     <AssemblyName>MonoDevelop.MSBuildEditor</AssemblyName>
     <LangVersion>8.0</LangVersion>
+    <CreatePackage Condition="'$(Configuration)' == 'Release'">true</CreatePackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,7 +39,7 @@
     <ProjectReference Include="..\MonoDevelop.Xml\Core\MonoDevelop.Xml.Core.csproj" />
     <ProjectReference Include="..\MonoDevelop.Xml\Editor\MonoDevelop.Xml.Editor.csproj" />
   </ItemGroup>
-  
+
   <Target Name="RemoveMonoDevelopRoslynAssemblies" BeforeTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <Reference Remove="@(Reference -> WithMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.Common'))" />

--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Syntax\*" />
     <EmbeddedResource Include="Syntax\msbuild.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <Compile Remove="Tests/**" />
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" />
     <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" />
     <AddinReference Include="MonoDevelop.DesignerSupport" />
     <AddinReference Include="MonoDevelop.SourceEditor2" />

--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -26,9 +26,7 @@
 
   <ItemGroup>
     <None Remove="Syntax\*" />
-    <EmbeddedResource Include="Syntax\msbuild.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
+    <AddinFile Include="Syntax\msbuild.json" />
     <AddinFile Include="Templates\Project.xft.xml" />
     <AddinFile Include="Templates\Project.xml" />
     <None Include="Syntax\OSSREADME.json" />

--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -1,108 +1,48 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{CBE54CAB-5DFE-477C-BE7F-65CB150BF5E1}</ProjectGuid>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace>MonoDevelop.MSBuildEditor</RootNamespace>
     <AssemblyName>MonoDevelop.MSBuildEditor</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <CreatePackage>True</CreatePackage>
-    <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\AddinInfo.cs" />
-    <Compile Include="PackageSearch\MonoDevelopPackageFeedRegistry.cs" />
-    <Compile Include="MSBuildCommands.cs" />
-    <Compile Include="MonoDevelopCompilationProvider.cs" />
-    <Compile Include="MonoDevelopMSBuildEditorHost.cs" />
-    <Compile Include="MonoDevelopRuntimeInformation.cs" />
-    <Compile Include="MonoDevelopSdkResolver.cs" />
-    <Compile Include="Analysis\CocoaDifferenceViewElementFactory.cs" />
-    <Compile Include="Analysis\CocoaMSBuildSuggestedAction.cs" />
-    <Compile Include="Analysis\ICocoaDifferenceViewerExtensions.cs" />
-    <Compile Include="MonoDevelopStreamingFindReferencesPresenter.cs" />
-    <Compile Include="Pads\MSBuildImportNavigatorPad.cs" />
-    <Compile Include="Pads\MSBuildImportNavigator.cs" />
-    <Compile Include="Pads\DocumentWithMimeTypeTracker.cs" />
-    <Compile Include="MSBuildCommandHandler.cs" />
-  </ItemGroup>
-  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+    <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" />
     <AddinReference Include="MonoDevelop.DesignerSupport" />
     <AddinReference Include="MonoDevelop.SourceEditor2" />
     <AddinReference Include="MonoDevelop.DotNetCore" />
     <AddinReference Include="MonoDevelop.PackageManagement" />
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
-    <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" />
     <AddinReference Include="MonoDevelop.TextEditor" />
     <AddinReference Include="MonoDevelop.Refactoring" />
     <AddinReference Include="MonoDevelop.TextEditor.Cocoa" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Properties\Manifest.addin.xml" />
     <EmbeddedResource Include="Syntax\msbuild.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
     <AddinFile Include="Templates\Project.xft.xml" />
     <AddinFile Include="Templates\Project.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Syntax\OSSREADME.json" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\MonoDevelop.MSBuild\MonoDevelop.MSBuild.csproj">
-      <Project>{E30D9BF7-2840-4274-A8A6-58D34295C6C8}</Project>
-      <Name>MonoDevelop.MSBuild</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\MonoDevelop.MSBuild.Editor\MonoDevelop.MSBuild.Editor.csproj">
-      <Project>{17E0FE72-B6D9-4187-BD80-D8A27BC74533}</Project>
-      <Name>MonoDevelop.MSBuild.Editor</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\MonoDevelop.Xml\Core\MonoDevelop.Xml.Core.csproj">
-      <Project>{87DE05FC-4B18-4C21-8AA5-237CB5B97780}</Project>
-      <Name>MonoDevelop.Xml.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\MonoDevelop.Xml\Editor\MonoDevelop.Xml.Editor.csproj">
-      <Project>{563FFDF7-0739-42DF-B987-B804A26D1E0B}</Project>
-      <Name>MonoDevelop.Xml.Editor</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\MonoDevelop.MSBuild\MonoDevelop.MSBuild.csproj" />
+    <ProjectReference Include="..\MonoDevelop.MSBuild.Editor\MonoDevelop.MSBuild.Editor.csproj" />
+    <ProjectReference Include="..\MonoDevelop.Xml\Core\MonoDevelop.Xml.Core.csproj" />
+    <ProjectReference Include="..\MonoDevelop.Xml\Editor\MonoDevelop.Xml.Editor.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Analysis\" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  
   <Target Name="RemoveMonoDevelopRoslynAssemblies" BeforeTargets="ResolveAssemblyReferences">
     <ItemGroup>
-      <Reference Remove="@(Reference-&gt;WithMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.Common'))" />
-      <Reference Remove="@(Reference-&gt;WithMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.CSharp'))" />
+      <Reference Remove="@(Reference -> WithMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.Common'))" />
+      <Reference Remove="@(Reference -> WithMetadataValue('NuGetPackageId', 'Microsoft.CodeAnalysis.CSharp'))" />
     </ItemGroup>
   </Target>
 

--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Update="Syntax\msbuild.json">
+    <EmbeddedResource Include="Syntax\msbuild.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
     <AddinFile Include="Templates\Project.xft.xml" />

--- a/MonoDevelop.MSBuildEditor/Properties/AssemblyInfo.cs
+++ b/MonoDevelop.MSBuildEditor/Properties/AssemblyInfo.cs
@@ -1,4 +1,0 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-
-[assembly: AssemblyTitle ("MonoDevelop.MSBuildEditor")]


### PR DESCRIPTION
Does what the title says. I also bumped the MSBuild package versions and fixed copying of the TextMate syntax JSON file into the addin archive. Enjoy!