### PR TITLE
Don't export IViewTaggerProvider for MSBuildTextMateTagger.

### DIFF
--- a/MonoDevelop.MSBuild.Editor/MSBuildTextMateTagger.cs
+++ b/MonoDevelop.MSBuild.Editor/MSBuildTextMateTagger.cs
@@ -5,26 +5,19 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 
 namespace MonoDevelop.MSBuild.Editor
 {
 	[Export (typeof (ITaggerProvider))]
-	[Export (typeof (IViewTaggerProvider))]
 	[TagType (typeof (IClassificationTag))]
 	[TagType (typeof (IStructureTag))]
 	[ContentType (MSBuildContentType.Name)]
-	sealed class MSBuildTextMateTagger : ITaggerProvider, IViewTaggerProvider
+	sealed class MSBuildTextMateTagger : ITaggerProvider
 	{
 		[Import]
 		ICommonEditorAssetServiceFactory assetServiceFactory = null;
-
-		public ITagger<T> CreateTagger<T> (ITextView view, ITextBuffer buffer) where T : ITag
-		{
-			return CreateTagger<T> (buffer);
-		}
 
 		public ITagger<T> CreateTagger<T> (ITextBuffer buffer) where T : ITag =>
 			assetServiceFactory.GetOrCreate (buffer)


### PR DESCRIPTION
The buffer tagger (ITaggerProvider) is sufficient and will properly tag the view. The buffer tagger will also properly work in scenarios that don't have a view, such as retrieving markers for the entire file for the vertical scrollbar.

A view tagger is primarily necessary when you need specific access to the view.

For this case it is redundant as all tags would appear twice, once from each tagger.