### PR TITLE
Disable Edit Project File commands

### DIFF
--- a/MonoDevelop.MSBuild.Editor.VisualStudio/EditProjectFileCommand.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/EditProjectFileCommand.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace MonoDevelop.MSBuild.Editor.VisualStudio
+{
+	[Order (10)]
+	[AppliesTo ("OpenProjectFile")]
+	[ExportCommandGroup ("{1496A755-94DE-11D0-8C3F-00C04FC2AAE2}")]
+	internal sealed class EditProjectFileCommand : IAsyncCommandGroupHandler
+	{
+		public Task<CommandStatusResult> GetCommandStatusAsync (IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string commandText, CommandStatus progressiveStatus)
+		{
+			if (commandId == 1632) {
+				return Task.FromResult (new CommandStatusResult (true, commandText, CommandStatus.Invisible | CommandStatus.NotSupported));
+			} else {
+				return Task.FromResult (CommandStatusResult.Unhandled);
+			}
+		}
+
+		public Task<bool> TryHandleCommandAsync (IImmutableSet<IProjectTree> nodes, long commandId, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+			=> Task.FromResult (false);
+	}
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/MonoDevelop.MSBuild.Editor.VisualStudio.csproj
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/MonoDevelop.MSBuild.Editor.VisualStudio.csproj
@@ -50,6 +50,8 @@
     <Compile Include="Analysis\IWpfDifferenceViewerExtensions.cs" />
     <Compile Include="Analysis\WpfMSBuildSuggestedAction.cs" />
     <Compile Include="Analysis\WpfDifferenceViewElementFactory.cs" />
+    <Compile Include="EditProjectFileCommand.cs" />
+    <Compile Include="OpenProjectEditorOnDefaultActionCommand.cs" />
     <Compile Include="RoslynFindReferences\DependencyObjectExtensions.cs" />
     <Compile Include="RoslynFindReferences\FindUsagesValueUsageInfoColumnDefinition.cs" />
     <Compile Include="MSBuildLanguageService.cs" />
@@ -133,10 +135,9 @@
     <VSSDKTargets Condition="'$(VSToolsPath)'!=''">$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets</VSSDKTargets>
   </PropertyGroup>
   <Import Project="$(VSSDKTargets)" Condition="Exists('$(VSSDKTargets)')" />
-
   <Target Name="AddVersionToVsix" BeforeTargets="CreateVsixContainer" DependsOnTargets="GetBuildVersion">
-		<PropertyGroup>
-			<TargetVsixContainer>$([System.IO.Path]::ChangeExtension('$(TargetVsixContainer)', '$(BuildVersion).vsix'))</TargetVsixContainer>
-		</PropertyGroup>
-	</Target>
+    <PropertyGroup>
+      <TargetVsixContainer>$([System.IO.Path]::ChangeExtension('$(TargetVsixContainer)', '$(BuildVersion).vsix'))</TargetVsixContainer>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectEditorOnDefaultActionCommand.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectEditorOnDefaultActionCommand.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace MonoDevelop.MSBuild.Editor.VisualStudio
+{
+	[Order (10)]
+	[AppliesTo ("OpenProjectFile")]
+	[ExportCommandGroup ("{60481700-078B-11D1-AAF8-00A0C9055A90}")]
+	internal sealed class OpenProjectEditorOnDefaultActionCommand : IAsyncCommandGroupHandler
+	{
+		public Task<CommandStatusResult> GetCommandStatusAsync (IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string commandText, CommandStatus progressiveStatus)
+		{
+			CommandStatusResult result = CommandStatusResult.Unhandled;
+
+			if (commandId == 2 || commandId == 3) {
+				result = new CommandStatusResult (true, commandText, CommandStatus.Enabled);
+			}
+
+			return Task.FromResult (result);
+		}
+
+		public Task<bool> TryHandleCommandAsync (IImmutableSet<IProjectTree> nodes, long commandId, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+			=> Task.FromResult (true);
+	}
+}


### PR DESCRIPTION
Until #20 is fixed (which is nontrivial, given that Visual Studio hard-codes the ID of its builtin XML editor in a closed-source DLL, and there is no way to override that decision), these commands will be useless. I have decided to override and hide them to reduce confusion and annoyance. You can still unload a project and then edit it, with or without these changes applied; that works just fine. If that issue is ever fixed, this PR can be cleanly reverted. Thanks!