### PR TITLE
Support any MSBuild project type

### DIFF
--- a/MonoDevelop.MSBuild.Editor/MSBuildContentType.cs
+++ b/MonoDevelop.MSBuild.Editor/MSBuildContentType.cs
@@ -37,36 +37,6 @@ namespace MonoDevelop.MSBuild.Editor
 		internal static FileExtensionToContentTypeDefinition MSBuildOverrideTasksFileExtensionDefinition;
 
 		[Export]
-		[FileExtension (".csproj")]
-		[ContentType (Name)]
-		internal static FileExtensionToContentTypeDefinition MSBuildCSProjFileExtensionDefinition;
-
-		[Export]
-		[FileExtension (".vbproj")]
-		[ContentType (Name)]
-		internal static FileExtensionToContentTypeDefinition MSBuildVBProjFileExtensionDefinition;
-
-		[Export]
-		[FileExtension (".fsproj")]
-		[ContentType (Name)]
-		internal static FileExtensionToContentTypeDefinition MSBuildFSProjFileExtensionDefinition;
-
-		[Export]
-		[FileExtension (".xproj")]
-		[ContentType (Name)]
-		internal static FileExtensionToContentTypeDefinition MSBuildXProjFileExtensionDefinition;
-
-		[Export]
-		[FileExtension (".vcxproj")]
-		[ContentType (Name)]
-		internal static FileExtensionToContentTypeDefinition MSBuildVCXProjFileExtensionDefinition;
-
-		[Export]
-		[FileExtension (".proj")]
-		[ContentType (Name)]
-		internal static FileExtensionToContentTypeDefinition MSBuildProjFileExtensionDefinition;
-
-		[Export]
 		[FileExtension (".user")]
 		[ContentType (Name)]
 		internal static FileExtensionToContentTypeDefinition MSBuildUserFileExtensionDefinition;

--- a/MonoDevelop.MSBuild.Editor/MSBuildContentTypeProvider.cs
+++ b/MonoDevelop.MSBuild.Editor/MSBuildContentTypeProvider.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.ComponentModel.Composition;
-using System.IO;
 using Microsoft.VisualStudio.Utilities;
 
 namespace MonoDevelop.MSBuild.Editor
@@ -17,8 +17,7 @@ namespace MonoDevelop.MSBuild.Editor
 
 		public bool TryGetContentTypeForFilePath (string filePath, out IContentType contentType)
 		{
-			string extension = Path.GetExtension (filePath).ToLowerInvariant ();
-			if (extension.EndsWith("proj")) {
+			if (filePath.EndsWith ("proj", StringComparison.OrdinalIgnoreCase)) {
 				contentType = ContentTypeRegistryService.GetContentType (MSBuildContentType.Name);
 				return true;
 			} else {

--- a/MonoDevelop.MSBuild.Editor/MSBuildContentTypeProvider.cs
+++ b/MonoDevelop.MSBuild.Editor/MSBuildContentTypeProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.IO;
 using Microsoft.VisualStudio.Utilities;
 
 namespace MonoDevelop.MSBuild.Editor
@@ -17,7 +18,8 @@ namespace MonoDevelop.MSBuild.Editor
 
 		public bool TryGetContentTypeForFilePath (string filePath, out IContentType contentType)
 		{
-			if (filePath.EndsWith ("proj", StringComparison.OrdinalIgnoreCase)) {
+			string extension = Path.GetExtension (filePath);
+			if (extension.EndsWith ("proj", StringComparison.OrdinalIgnoreCase)) {
 				contentType = ContentTypeRegistryService.GetContentType (MSBuildContentType.Name);
 				return true;
 			} else {

--- a/MonoDevelop.MSBuild.Editor/MSBuildContentTypeProvider.cs
+++ b/MonoDevelop.MSBuild.Editor/MSBuildContentTypeProvider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel.Composition;
+using System.IO;
+using Microsoft.VisualStudio.Utilities;
+
+namespace MonoDevelop.MSBuild.Editor
+{
+	[Export(typeof(IFilePathToContentTypeProvider))]
+	[Name("MSBuild Content Type Provider")]
+	[FileExtension("*")]
+	class MSBuildContentTypeProvider : IFilePathToContentTypeProvider
+	{
+		[Import]
+		private IContentTypeRegistryService ContentTypeRegistryService { get; set; }
+
+		public bool TryGetContentTypeForFilePath (string filePath, out IContentType contentType)
+		{
+			string extension = Path.GetExtension (filePath).ToLowerInvariant ();
+			if (extension.EndsWith("proj")) {
+				contentType = ContentTypeRegistryService.GetContentType (MSBuildContentType.Name);
+				return true;
+			} else {
+				contentType = null;
+				return false;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR makes the MSBuild Editor aware of any file following the `*.*proj` convention for MSBuild projects. For example, `*.wapproj` and `*.wixproj` file types will now be recognized.