### PR TITLE
Implement custom editor factory

### DIFF
--- a/MonoDevelop.MSBuild.Editor.VisualStudio/MSBuildEditorVisualStudioPackage.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/MSBuildEditorVisualStudioPackage.cs
@@ -34,6 +34,7 @@ namespace MonoDevelop.MSBuild.Editor.VisualStudio
 	[ProvideLanguageExtension (typeof (MSBuildLanguageService), ".vcxproj")]
 	[ProvideLanguageExtension (typeof (MSBuildLanguageService), ".proj")]
 	[ProvideLanguageExtension (typeof (MSBuildLanguageService), ".user")]
+	[ProvideEditorFactory (typeof (MSBuildEditorFactory), 1, CommonPhysicalViewAttributes = 0x2, TrustLevel = Microsoft.VisualStudio.Shell.Interop.__VSEDITORTRUSTLEVEL.ETL_AlwaysTrusted)]
 	public sealed class MSBuildEditorVisualStudioPackage : AsyncPackage
 	{
 		public const string PackageGuidString = "6c7bd60d-5321-4fb0-8684-9736003d64ad";
@@ -41,6 +42,9 @@ namespace MonoDevelop.MSBuild.Editor.VisualStudio
 		public const string LanguageServiceKey = @"Languages\Language Services\" + LanguageServiceName;
 
 		protected override Task InitializeAsync (CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
-			=> Task.CompletedTask;
+		{
+			RegisterEditorFactory (new MSBuildEditorFactory (this));
+			return Task.CompletedTask;
+		}
 	}
 }

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/MonoDevelop.MSBuild.Editor.VisualStudio.csproj
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/MonoDevelop.MSBuild.Editor.VisualStudio.csproj
@@ -50,6 +50,9 @@
     <Compile Include="Analysis\IWpfDifferenceViewerExtensions.cs" />
     <Compile Include="Analysis\WpfMSBuildSuggestedAction.cs" />
     <Compile Include="Analysis\WpfDifferenceViewElementFactory.cs" />
+    <Compile Include="OpenProjectFile\EditProjectFileCommand.cs" />
+    <Compile Include="OpenProjectFile\MSBuildEditorFactory.cs" />
+    <Compile Include="OpenProjectFile\OpenProjectEditorOnDefaultActionCommand.cs" />
     <Compile Include="RoslynFindReferences\DependencyObjectExtensions.cs" />
     <Compile Include="RoslynFindReferences\FindUsagesValueUsageInfoColumnDefinition.cs" />
     <Compile Include="MSBuildLanguageService.cs" />
@@ -133,10 +136,9 @@
     <VSSDKTargets Condition="'$(VSToolsPath)'!=''">$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets</VSSDKTargets>
   </PropertyGroup>
   <Import Project="$(VSSDKTargets)" Condition="Exists('$(VSSDKTargets)')" />
-
   <Target Name="AddVersionToVsix" BeforeTargets="CreateVsixContainer" DependsOnTargets="GetBuildVersion">
-		<PropertyGroup>
-			<TargetVsixContainer>$([System.IO.Path]::ChangeExtension('$(TargetVsixContainer)', '$(BuildVersion).vsix'))</TargetVsixContainer>
-		</PropertyGroup>
-	</Target>
+    <PropertyGroup>
+      <TargetVsixContainer>$([System.IO.Path]::ChangeExtension('$(TargetVsixContainer)', '$(BuildVersion).vsix'))</TargetVsixContainer>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectFile/EditProjectFileCommand.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectFile/EditProjectFileCommand.cs
@@ -41,11 +41,8 @@ namespace MonoDevelop.MSBuild.Editor.VisualStudio
 			if (commandId != 1632) return false;
 
 			await ProjectThreadingService.SwitchToUIThread ();
-			try {
-				var windowFrame = VsShellUtilities.OpenDocumentWithSpecificEditor (ServiceProvider, UnconfiguredProject.FullPath, new Guid (MSBuildEditorFactory.FactoryGuid), Guid.Empty);
-				windowFrame?.Show ();
-			} catch {
-			}
+			var windowFrame = VsShellUtilities.OpenDocumentWithSpecificEditor (ServiceProvider, UnconfiguredProject.FullPath, new Guid (MSBuildEditorFactory.FactoryGuid), Guid.Empty);
+			windowFrame?.Show ();
 
 			return true;
 		}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectFile/EditProjectFileCommand.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectFile/EditProjectFileCommand.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace MonoDevelop.MSBuild.Editor.VisualStudio
+{
+	[Order (10)]
+	[AppliesTo ("OpenProjectFile")]
+	[ExportCommandGroup ("{1496A755-94DE-11D0-8C3F-00C04FC2AAE2}")]
+	internal sealed class EditProjectFileCommand : IAsyncCommandGroupHandler
+	{
+		[Import]
+		private UnconfiguredProject UnconfiguredProject { get; set; }
+
+		[Import (typeof (SVsServiceProvider))]
+		private IServiceProvider ServiceProvider { get; set; }
+
+		[Import]
+		private IProjectThreadingService ProjectThreadingService { get; set; }
+
+		public Task<CommandStatusResult> GetCommandStatusAsync (IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string commandText, CommandStatus progressiveStatus)
+		{
+			if (commandId == 1632) {
+				return Task.FromResult (new CommandStatusResult (true, commandText, CommandStatus.Enabled | CommandStatus.Supported));
+			} else {
+				return Task.FromResult (CommandStatusResult.Unhandled);
+			}
+		}
+
+		public async Task<bool> TryHandleCommandAsync (IImmutableSet<IProjectTree> nodes, long commandId, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+		{
+			if (commandId != 1632) return false;
+
+			await ProjectThreadingService.SwitchToUIThread ();
+			try {
+				var windowFrame = VsShellUtilities.OpenDocumentWithSpecificEditor (ServiceProvider, UnconfiguredProject.FullPath, new Guid (MSBuildEditorFactory.FactoryGuid), Guid.Empty);
+				windowFrame?.Show ();
+			} catch {
+			}
+
+			return true;
+		}
+	}
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectFile/MSBuildEditorFactory.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectFile/MSBuildEditorFactory.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace MonoDevelop.MSBuild.Editor.VisualStudio
+{
+	[Guid (FactoryGuid)]
+	[ComVisible (true)]
+	internal sealed class MSBuildEditorFactory : IVsEditorFactory
+	{
+		public const string FactoryGuid = "351a6d4d-a558-4547-b825-e381869f5c92";
+
+		private System.IServiceProvider serviceProvider;
+		private readonly Package package;
+
+		public MSBuildEditorFactory (Package package)
+		{
+			this.package = package;
+		}
+
+		[System.Diagnostics.CodeAnalysis.SuppressMessage ("Usage", "VSTHRD010:Invoke single-threaded types on Main thread", Justification = "Can't import IProjectThreadingService here")]
+		public int CreateEditorInstance (uint grfCreateDoc, string pszMkDocument, string pszPhysicalView, IVsHierarchy pvHier, uint itemid, IntPtr punkDocDataExisting, out IntPtr ppunkDocView, out IntPtr ppunkDocData, out string pbstrEditorCaption, out Guid pguidCmdUI, out int pgrfCDW)
+		{
+			int result = 0;
+
+			ppunkDocView = IntPtr.Zero;
+			ppunkDocData = IntPtr.Zero;
+			pbstrEditorCaption = null;
+			pguidCmdUI = Guid.Empty;
+			pgrfCDW = 0;
+
+			IVsTextLines lines;
+
+			if (punkDocDataExisting != IntPtr.Zero) {
+				object rcw = Marshal.GetObjectForIUnknown (punkDocDataExisting);
+				lines = rcw as IVsTextLines;
+
+				if (lines == null) {
+					if (rcw is IVsTextBufferProvider provider) {
+						ThrowOnError (provider.GetTextBuffer (out lines));
+					}
+				}
+
+				if (lines == null) {
+					result = unchecked((int)0x80041FEA);
+					goto cleanup;
+				}
+			} else {
+				Type linesType = typeof (IVsTextLines);
+				Guid linesIID = linesType.GUID;
+				Guid linesCLSID = typeof (VsTextBufferClass).GUID;
+
+				lines = (IVsTextLines)package.CreateInstance (ref linesCLSID, ref linesIID, linesType);
+				if (!string.IsNullOrEmpty (pszMkDocument)) {
+					if (lines is IVsUserData userData) {
+						Guid userDataGuid = typeof (IVsUserData).GUID;
+						ThrowOnError (userData.SetData (ref userDataGuid, pszMkDocument));
+					}
+				}
+
+				if (lines is IObjectWithSite objectWithSite) {
+					objectWithSite.SetSite (serviceProvider.GetService (typeof (Microsoft.VisualStudio.OLE.Interop.IServiceProvider)));
+				}
+			}
+
+			Guid serviceId = new Guid (MSBuildLanguageService.Guid);
+			lines.SetLanguageServiceID (ref serviceId);
+
+			if (lines is IVsUserData linesData) {
+				Guid detectLanguageSid = new Guid (401831340u, 51220, 4561, 136, 173, 0, 0, 248, 117, 121, 210);
+				ThrowOnError (linesData.SetData (ref detectLanguageSid, false));
+			}
+
+			if (punkDocDataExisting != IntPtr.Zero) {
+				ppunkDocData = punkDocDataExisting;
+				Marshal.AddRef (punkDocDataExisting);
+			} else {
+				ppunkDocData = Marshal.GetIUnknownForObject (lines);
+			}
+
+			Type codeWindowType = typeof (IVsCodeWindow);
+			Guid codeWindowIID = codeWindowType.GUID;
+			Guid codeWindowCLSID = typeof (VsCodeWindowClass).GUID;
+			IVsCodeWindow codeWindow = (IVsCodeWindow)package.CreateInstance (ref codeWindowCLSID, ref codeWindowIID, codeWindowType);
+			ThrowOnError (codeWindow.SetBuffer (lines));
+			ThrowOnError (codeWindow.SetBaseEditorCaption (null));
+			ThrowOnError (codeWindow.GetEditorCaption (READONLYSTATUS.ROSTATUS_Unknown, out pbstrEditorCaption));
+			pguidCmdUI = new Guid (2335713320u, 25090, 4561, 136, 112, 0, 0, 248, 117, 121, 210);
+
+			ppunkDocView = Marshal.GetIUnknownForObject (codeWindow);
+			if (ppunkDocView == IntPtr.Zero) result = unchecked((int)0x80041FEB);
+
+			cleanup:
+			if (ppunkDocView == IntPtr.Zero && ppunkDocData != punkDocDataExisting && ppunkDocData != IntPtr.Zero) {
+				Marshal.Release (ppunkDocData);
+				ppunkDocData = IntPtr.Zero;
+			}
+
+			return result;
+		}
+
+		public int SetSite (Microsoft.VisualStudio.OLE.Interop.IServiceProvider psp)
+		{
+			serviceProvider = new ServiceProvider (psp);
+			return HResult.OK;
+		}
+
+		public int Close () => HResult.OK;
+
+		public int MapLogicalView (ref Guid rguidLogicalView, out string pbstrPhysicalView)
+		{
+			pbstrPhysicalView = null;
+
+			Guid LOGVIEWID_Code = new Guid ("7651a701-06e5-11d1-8ebd-00a0c90f26ea");
+			Guid LOGVIEWID_Debugging = new Guid ("7651a700-06e5-11d1-8ebd-00a0c90f26ea");
+			Guid LOGVIEWID_TextView = new Guid ("7651a703-06e5-11d1-8ebd-00a0c90f26ea");
+			Guid LOGVIEWID_Primary = Guid.Empty;
+
+			if (rguidLogicalView == LOGVIEWID_Code || rguidLogicalView == LOGVIEWID_Debugging || rguidLogicalView == LOGVIEWID_TextView || rguidLogicalView == LOGVIEWID_Primary) {
+				pbstrPhysicalView = null;
+				return 0;
+			}
+
+			return unchecked((int)0x80004001);
+		}
+
+		private static void ThrowOnError (int hr)
+		{
+			if (hr < 0) Marshal.ThrowExceptionForHR (hr);
+		}
+	}
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectFile/OpenProjectEditorOnDefaultActionCommand.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/OpenProjectFile/OpenProjectEditorOnDefaultActionCommand.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace MonoDevelop.MSBuild.Editor.VisualStudio
+{
+	[Order (10)]
+	[AppliesTo ("OpenProjectFile")]
+	[ExportCommandGroup ("{60481700-078B-11D1-AAF8-00A0C9055A90}")]
+	internal sealed class OpenProjectEditorOnDefaultActionCommand : IAsyncCommandGroupHandler
+	{
+		[Import]
+		private UnconfiguredProject UnconfiguredProject { get; set; }
+
+		[Import (typeof (SVsServiceProvider))]
+		private IServiceProvider ServiceProvider { get; set; }
+
+		[Import]
+		private IProjectThreadingService ProjectThreadingService { get; set; }
+
+		public Task<CommandStatusResult> GetCommandStatusAsync (IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string commandText, CommandStatus progressiveStatus)
+		{
+			CommandStatusResult result = CommandStatusResult.Unhandled;
+
+			if (commandId == 2 || commandId == 3) {
+				result = new CommandStatusResult (true, commandText, CommandStatus.Enabled);
+			}
+
+			return Task.FromResult (result);
+		}
+
+		public async Task<bool> TryHandleCommandAsync (IImmutableSet<IProjectTree> nodes, long commandId, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+		{
+			if (nodes != null && nodes.Count == 1 && nodes.First ().IsRoot ()) {
+				if (!(commandId == 2 || commandId == 3)) return false;
+
+				await ProjectThreadingService.SwitchToUIThread ();
+				var windowFrame = VsShellUtilities.OpenDocumentWithSpecificEditor (ServiceProvider, UnconfiguredProject.FullPath, new Guid (MSBuildEditorFactory.FactoryGuid), Guid.Empty);
+				windowFrame?.Show ();
+
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This editor factory implementation successfully loads the project files using the MSBuild language service and the services in MonoDevelop.Xml.Editor.dll. However, it is still unusable, due to constant "Project requires manual reload" popups during editing (that both interrupt typing, and on at least one occasion rewrote the project file according to Visual Studio's whims, a la vcxproj).

I do not know what is causing these popups, other than they seem to be triggered by opening the IntelliSense popup and using the arrow keys to navigate through the list. Editing of props/targets files is seemingly unaffected. I am creating this PR as a draft for this reason.