### PR TITLE
Fix parsing of <Import Sdk="" Project="" /> syntax

### DIFF
--- a/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
@@ -142,7 +142,7 @@ namespace MonoDevelop.MSBuild.Language
 			if (sdkAtt?.Value is ExpressionText sdkTxt) {
 				var loc = sdkAtt.XAttribute.ValueSpan;
 				string sdkPath = parseContext.GetSdkPath (this, sdkTxt.Value, loc);
-				import = import == null ? null : new ExpressionText (0, sdkPath + "\\" + import, true);
+				import = import == null ? null : new ExpressionText (0, sdkPath + System.IO.Path.DirectorySeparatorChar + importTxt, true);
 
 				if (IsToplevel && sdkPath != null) {
 					Annotations.Add (sdkAtt.XAttribute, new NavigationAnnotation (sdkPath, loc));
@@ -161,7 +161,7 @@ namespace MonoDevelop.MSBuild.Language
 				}
 				if (!wasResolved && IsToplevel) {
 					DiagnosticSeverity type = element.ConditionAttribute == null ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning;
-					Diagnostics.Add (CoreDiagnostics.UnresolvedImport, loc, import);
+					Diagnostics.Add (CoreDiagnostics.UnresolvedImport, loc, importTxt);
 				}
 			}
 		}


### PR DESCRIPTION
Previously, it would resolve the SDK, but not the specific file, and emit a file-not-found warning on the value of the Project attribute.