### PR TITLE
Fix MSBuild 16.8 / net 5.0 support

### DIFF
--- a/.github/workflows/vsmac.yml
+++ b/.github/workflows/vsmac.yml
@@ -4,35 +4,32 @@ on: [push]
 
 jobs:
   VSMac:
-    runs-on: macOS-latest
-    env:
-      # for some reason 5.12 is in PATH
-      MONO_BIN: /Library/Frameworks/Mono.framework/Versions/6.4.0/bin
+    runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
-        
-    # work around GenerateDepsFile NuGet mismatch
-    # https://github.com/NuGet/Home/issues/7956
+        fetch-depth: 0 # GitVersioning needs deep clone
+
     - name: Set up dotnet
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '2.2.402'
+        dotnet-version: '5.0.x'
 
     - name: Restore
-      run: PATH=$MONO_BIN:$PATH msbuild -t:Restore -p:Configuration=ReleaseMac
-      
-    - name: Build
-      run: PATH=$MONO_BIN:$PATH msbuild MonoDevelop.MSBuildEditor.sln -p:Configuration=ReleaseMac -p:CreatePackage=true
-      
-    - name: Download NUnit
-      run: PATH=$MONO_BIN:$PATH nuget install NUnit.ConsoleRunner -Version 3.8.0 -OutputDirectory testrunner
-      
-    - name: Test
-      run: PATH=$MONO_BIN:$PATH mono ./testrunner/NUnit.ConsoleRunner.3.8.0/tools/nunit3-console.exe ./MonoDevelop.MSBuild.Tests/bin/Release/MonoDevelop.MSBuild.Tests.dll
+      run: mono /Applications/Visual\ Studio.app/Contents/Resources/lib/monodevelop/bin/MSBuild/Current/bin/MSBuild.dll -t:Restore -p:Configuration=ReleaseMac
 
-    - uses: actions/upload-artifact@master
+    - name: Build
+      run: |
+        mono /Applications/Visual\ Studio.app/Contents/Resources/lib/monodevelop/bin/MSBuild/Current/bin/MSBuild.dll MonoDevelop.MSBuildEditor.sln -p:Configuration=ReleaseMac -p:CreatePackage=true
+
+    - name: Download NUnit
+      run: nuget install NUnit.ConsoleRunner -Version 3.11.1 -OutputDirectory testrunner
+
+    - name: Test
+      run: mono ./testrunner/NUnit.ConsoleRunner.3.11.1/tools/nunit3-console.exe ./MonoDevelop.MSBuild.Tests/bin/Release/MonoDevelop.MSBuild.Tests.dll
+
+    - uses: actions/upload-artifact@v2
       with:
         name: MSBuild Editor for Visual Studio for Mac
-        path: MonoDevelop.MSBuildEditor/bin/Release/MonoDevelop.MSBuildEditor.MonoDevelop.MSBuildEditor_2.3.1.mpack
+        path: MonoDevelop.MSBuildEditor/bin/Release/net472/*.mpack

--- a/.github/workflows/vswin.yml
+++ b/.github/workflows/vswin.yml
@@ -6,32 +6,36 @@ jobs:
   VSWin:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
-        
+        fetch-depth: 0 # GitVersioning needs deep clone
+
+    - name: Set up dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
+
     - name: Find MSBuild
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Restore
       run: msbuild -t:Restore -p:Configuration=Release
-      
+
     - name: Build
       run: |
         msbuild MonoDevelop.MSBuildEditor.sln -p:Configuration=Release -m -p:CreatePackage=true
-        mkdir -p vsix
-        copy MonoDevelop.MSBuild.Editor.VisualStudio/bin/Release/MonoDevelop.MSBuild.Editor.VisualStudio.*.vsix vsix
-    
+
     - name: Set up Nuget.exe
-      uses: NuGet/setup-nuget@v1.0.2
-      
+      uses: NuGet/setup-nuget@v1
+
     - name: Download NUnit
-      run: nuget install NUnit.ConsoleRunner -Version 3.8.0 -OutputDirectory testrunner
-      
+      run: nuget install NUnit.ConsoleRunner -Version 3.11.1 -OutputDirectory testrunner
+
     - name: Test
-      run: .\testrunner\NUnit.ConsoleRunner.3.8.0\tools\nunit3-console.exe .\MonoDevelop.MSBuild.Tests\bin\Release\MonoDevelop.MSBuild.Tests.dll
-      
+      run: .\testrunner\NUnit.ConsoleRunner.3.11.1\tools\nunit3-console.exe .\MonoDevelop.MSBuild.Tests\bin\Release\MonoDevelop.MSBuild.Tests.dll
+
     - uses: actions/upload-artifact@master
       with:
         name: MSBuild Editor for Visual Studio
-        path: vsix
+        path: MonoDevelop.MSBuild.Editor.VisualStudio/bin/Release/MonoDevelop.MSBuild.Editor.VisualStudio.*.vsix

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,9 +3,10 @@
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)private.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.26" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/Analysis/WpfMSBuildSuggestedAction.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/Analysis/WpfMSBuildSuggestedAction.cs
@@ -25,7 +25,6 @@ namespace MonoDevelop.MSBuild.Editor.Analysis
 	{
 		readonly PreviewChangesService previewService;
 		readonly ITextView textView;
-		readonly IEditorOptions options;
 		readonly ITextBuffer buffer;
 		readonly MSBuildCodeFix fix;
 

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/MonoDevelop.MSBuild.Editor.VisualStudio.csproj
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/MonoDevelop.MSBuild.Editor.VisualStudio.csproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>16.8</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -93,12 +93,17 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="16.4.29313.133" />
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="16.8.30523.219" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices">
-      <Version>3.0.0</Version>
+      <Version>3.8.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.200" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.2.3071" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonoDevelop.MSBuild.Editor\MonoDevelop.MSBuild.Editor.csproj">
@@ -133,10 +138,9 @@
     <VSSDKTargets Condition="'$(VSToolsPath)'!=''">$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets</VSSDKTargets>
   </PropertyGroup>
   <Import Project="$(VSSDKTargets)" Condition="Exists('$(VSSDKTargets)')" />
-
   <Target Name="AddVersionToVsix" BeforeTargets="CreateVsixContainer" DependsOnTargets="GetBuildVersion">
-		<PropertyGroup>
-			<TargetVsixContainer>$([System.IO.Path]::ChangeExtension('$(TargetVsixContainer)', '$(BuildVersion).vsix'))</TargetVsixContainer>
-		</PropertyGroup>
-	</Target>
+    <PropertyGroup>
+      <TargetVsixContainer>$([System.IO.Path]::ChangeExtension('$(TargetVsixContainer)', '$(BuildVersion).vsix'))</TargetVsixContainer>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/MonoDevelop.MSBuild.Editor/MonoDevelop.MSBuild.Editor.csproj
+++ b/MonoDevelop.MSBuild.Editor/MonoDevelop.MSBuild.Editor.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <LangVersion>8.0</LangVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -19,8 +18,8 @@
     <ProjectReference Include="..\MonoDevelop.Xml\Core\MonoDevelop.Xml.Core.csproj" />
     <ProjectReference Include="..\MonoDevelop.Xml\Editor\MonoDevelop.Xml.Editor.csproj" />
     <ProjectReference Include="..\MonoDevelop.MSBuild\MonoDevelop.MSBuild.csproj" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="16.4.29313.133" />
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="16.4.66" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="16.4.66" />

--- a/MonoDevelop.MSBuild.Tests/MSBuildImportEvaluationTests.cs
+++ b/MonoDevelop.MSBuild.Tests/MSBuildImportEvaluationTests.cs
@@ -154,6 +154,20 @@ namespace MonoDevelop.MSBuild.Tests
 			Assert.AreEqual (MSBuildValueKind.NuGetID, packageRefItem.ValueKind);
 		}
 
+		[Test]
+		public void TestImportWithSdk ()
+		{
+			var doc = ParseDoc (
+				"<Project><Import Project=\"Sdk.props\" Sdk=\"Microsoft.NET.Sdk\" /></Project>",
+				"myfile.csproj"
+			);
+
+			AssertImportsExist (
+				doc,
+				"Microsoft.NET.Sdk.DefaultItems.props"
+			);
+		}
+
 		static MSBuildRootDocument ParseDoc (string contents, string filename = "myfile.csproj")
 		{
 			var runtimeInfo = new MSBuildEnvironmentRuntimeInformation ();

--- a/MonoDevelop.MSBuild.Tests/MSBuildTestHelpers.cs
+++ b/MonoDevelop.MSBuild.Tests/MSBuildTestHelpers.cs
@@ -106,6 +106,13 @@ namespace MonoDevelop.MSBuild.Tests
 			}
 
 			if (Platform.IsMac) {
+				//TODO: locate app bundle by id
+				var vsmacMSBuildDir = "/Applications/Visual Studio.app/Contents/Resources/lib/monodevelop/bin/MSBuild/Current/bin";
+				if (Directory.Exists(vsmacMSBuildDir)) {
+					Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath (vsmacMSBuildDir);
+					return;
+				}
+
 				var corlibDir = Path.GetDirectoryName (typeof (string).Assembly.Location);
 				var msbuildDir = Path.Combine (corlibDir, "..", "msbuild", "Current", "bin");
 				Microsoft.Build.Locator.MSBuildLocator.RegisterMSBuildPath (msbuildDir);

--- a/MonoDevelop.MSBuild.Tests/MonoDevelop.MSBuild.Tests.csproj
+++ b/MonoDevelop.MSBuild.Tests/MonoDevelop.MSBuild.Tests.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neteril.VisualStudio.MiniEditor" Version="1.0.11" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Include="Neteril.VisualStudio.MiniEditor" Version="1.0.52" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" ExcludeAssets="runtime" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.Build" Version="16.8.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoDevelop.MSBuild.Tests/MonoDevelop.MSBuild.Tests.csproj
+++ b/MonoDevelop.MSBuild.Tests/MonoDevelop.MSBuild.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net472</TargetFramework>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <NUnitDisableSupportAssemblies>true</NUnitDisableSupportAssemblies>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 using MonoDevelop.MSBuild.Analysis;
@@ -142,7 +143,7 @@ namespace MonoDevelop.MSBuild.Language
 			if (sdkAtt?.Value is ExpressionText sdkTxt) {
 				var loc = sdkAtt.XAttribute.ValueSpan;
 				string sdkPath = parseContext.GetSdkPath (this, sdkTxt.Value, loc);
-				import = import == null ? null : new ExpressionText (0, sdkPath + System.IO.Path.DirectorySeparatorChar + importTxt, true);
+				import = import == null ? null : new ExpressionText (0, Path.Combine (sdkPath, importTxt), true);
 
 				if (IsToplevel && sdkPath != null) {
 					Annotations.Add (sdkAtt.XAttribute, new NavigationAnnotation (sdkPath, loc));

--- a/MonoDevelop.MSBuild/MonoDevelop.MSBuild.csproj
+++ b/MonoDevelop.MSBuild/MonoDevelop.MSBuild.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!--
+    build net5.0 as well to make sure we don't accidentally add netframework deps
+    even though only the net472 version is actually used right now
+    -->
     <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/MonoDevelop.MSBuild/MonoDevelop.MSBuild.csproj
+++ b/MonoDevelop.MSBuild/MonoDevelop.MSBuild.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -27,11 +26,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build" Version="16.8.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="4.9.3" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="NuGet.Frameworks" Version="5.8.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoDevelop.MSBuild/Schema/ElementDescriptions.Designer.cs
+++ b/MonoDevelop.MSBuild/Schema/ElementDescriptions.Designer.cs
@@ -19,7 +19,7 @@ namespace MonoDevelop.MSBuild.Schema {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ElementDescriptions {

--- a/MonoDevelop.MSBuild/SdkResolution/MSBuildSdkResolver.cs
+++ b/MonoDevelop.MSBuild/SdkResolution/MSBuildSdkResolver.cs
@@ -273,17 +273,28 @@ namespace MonoDevelop.MSBuild.SdkResolution
 				Warnings = warnings;
 			}
 
-			public SdkResultImpl (SdkReference sdkReference, string path, string version, IEnumerable<string> warnings)
+			public SdkResultImpl (SdkReference sdkReference, string path, string version,
+				IDictionary<string, string> propertiesToAdd, IDictionary<string, SdkResultItem> itemsToAdd, IEnumerable<string> warnings)
 			{
 				Success = true;
 				Sdk = sdkReference;
+				PropertiesToAdd = propertiesToAdd;
+				ItemsToAdd = itemsToAdd;
 				Path = path;
 				Version = version;
 				Warnings = warnings;
 			}
 
-			public SdkReference Sdk { get; }
+			public SdkResultImpl (SdkReference sdkReference, IEnumerable<string> paths, string version,
+				IDictionary<string, string> propertiesToAdd, IDictionary<string, SdkResultItem> itemsToAdd, IEnumerable<string> warnings)
+				: this (sdkReference, paths.FirstOrDefault(), version, propertiesToAdd, itemsToAdd, warnings)
+			{
+				if (paths.Count() > 1) {
+					AdditionalPaths = paths.Skip (1).ToList ();
+				}
+			}
 
+			public SdkReference Sdk { get; }
 			public IEnumerable<string> Errors { get; }
 
 			public IEnumerable<string> Warnings { get; }
@@ -300,12 +311,22 @@ namespace MonoDevelop.MSBuild.SdkResolution
 
 			public override SdkResult IndicateSuccess (string path, string version, IEnumerable<string> warnings = null)
 			{
-				return new SdkResultImpl (_sdkReference, path, version, warnings);
+				return new SdkResultImpl (_sdkReference, path, version, null, null, warnings);
 			}
 
 			public override SdkResult IndicateFailure (IEnumerable<string> errors, IEnumerable<string> warnings = null)
 			{
 				return new SdkResultImpl (_sdkReference, errors, warnings);
+			}
+
+			public override SdkResult IndicateSuccess (IEnumerable<string> paths, string version, IDictionary<string, string> propertiesToAdd = null, IDictionary<string, SdkResultItem> itemsToAdd = null, IEnumerable<string> warnings = null)
+			{
+				return new SdkResultImpl (_sdkReference, paths, version, propertiesToAdd, itemsToAdd, warnings);
+			}
+
+			public override SdkResult IndicateSuccess (string path, string version, IDictionary<string, string> propertiesToAdd, IDictionary<string, SdkResultItem> itemsToAdd, IEnumerable<string> warnings = null)
+			{
+				return new SdkResultImpl (_sdkReference, path, version, propertiesToAdd, itemsToAdd, warnings);
 			}
 		}
 

--- a/MonoDevelop.MSBuildEditor.sln
+++ b/MonoDevelop.MSBuildEditor.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5A6AA30D-5371-4431-9299-D8F793536DEC}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
 		README.md = README.md
 		TODO.md = TODO.md
 	EndProjectSection

--- a/MonoDevelop.MSBuildEditor.sln
+++ b/MonoDevelop.MSBuildEditor.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 16.0.29009.5
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoDevelop.MSBuildEditor", "MonoDevelop.MSBuildEditor\MonoDevelop.MSBuildEditor.csproj", "{CBE54CAB-5DFE-477C-BE7F-65CB150BF5E1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoDevelop.MSBuildEditor.Tests", "MonoDevelop.MSBuildEditor\Tests\MonoDevelop.MSBuildEditor.Tests.csproj", "{A345C0C4-4752-4CC6-B8C0-C1541CD4A2E9}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5A6AA30D-5371-4431-9299-D8F793536DEC}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -45,12 +43,6 @@ Global
 		{CBE54CAB-5DFE-477C-BE7F-65CB150BF5E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBE54CAB-5DFE-477C-BE7F-65CB150BF5E1}.ReleaseMac|Any CPU.ActiveCfg = Release|Any CPU
 		{CBE54CAB-5DFE-477C-BE7F-65CB150BF5E1}.ReleaseMac|Any CPU.Build.0 = Release|Any CPU
-		{A345C0C4-4752-4CC6-B8C0-C1541CD4A2E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A345C0C4-4752-4CC6-B8C0-C1541CD4A2E9}.DebugMac|Any CPU.ActiveCfg = Debug|Any CPU
-		{A345C0C4-4752-4CC6-B8C0-C1541CD4A2E9}.DebugMac|Any CPU.Build.0 = Debug|Any CPU
-		{A345C0C4-4752-4CC6-B8C0-C1541CD4A2E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A345C0C4-4752-4CC6-B8C0-C1541CD4A2E9}.ReleaseMac|Any CPU.ActiveCfg = Release|Any CPU
-		{A345C0C4-4752-4CC6-B8C0-C1541CD4A2E9}.ReleaseMac|Any CPU.Build.0 = Release|Any CPU
 		{87DE05FC-4B18-4C21-8AA5-237CB5B97780}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{87DE05FC-4B18-4C21-8AA5-237CB5B97780}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{87DE05FC-4B18-4C21-8AA5-237CB5B97780}.DebugMac|Any CPU.ActiveCfg = Debug|Any CPU

--- a/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
+++ b/MonoDevelop.MSBuildEditor/MonoDevelop.MSBuildEditor.csproj
@@ -5,14 +5,14 @@
     <OutputType>Library</OutputType>
     <RootNamespace>MonoDevelop.MSBuildEditor</RootNamespace>
     <AssemblyName>MonoDevelop.MSBuildEditor</AssemblyName>
-    <LangVersion>8.0</LangVersion>
     <CreatePackage Condition="'$(Configuration)' == 'Release'">true</CreatePackage>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="Tests/**" />
-    <PackageReference Include="Microsoft.Build" Version="16.4.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.8.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.8.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.8.0" />
     <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" />
     <AddinReference Include="MonoDevelop.DesignerSupport" />
     <AddinReference Include="MonoDevelop.SourceEditor2" />


### PR DESCRIPTION
Due to a change in the MSBuild SDK resolver contract that was made for for .NET 5.0, the extension didn't work with MSBuild 16.8+