### PR TITLE
Fix triggering ctrl-space completion

### DIFF
--- a/MonoDevelop.MSBuild.Editor.VisualStudio/MSBuildEditorFactory.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/MSBuildEditorFactory.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.LanguageServices.Implementation;
+
+namespace MonoDevelop.MSBuild.Editor.VisualStudio
+{
+	[ComVisible (true)]
+	[Guid (PackageConsts.EditorFactoryGuid)]
+	class MSBuildEditorFactory : AbstractEditorFactory
+	{
+		public MSBuildEditorFactory (IComponentModel componentModel) : base (componentModel) { }
+
+		protected override string ContentTypeName => MSBuildContentType.Name;
+
+		protected override string LanguageName => PackageConsts.LanguageServiceName;
+	}
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/MSBuildLanguageService.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/MSBuildLanguageService.cs
@@ -3,57 +3,87 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
-using Microsoft.VisualStudio.Package;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService;
 using Microsoft.VisualStudio.TextManager.Interop;
 
-using Community.VisualStudio.Toolkit;
+namespace MonoDevelop.MSBuild.Editor.VisualStudio;
 
-namespace MonoDevelop.MSBuild.Editor.VisualStudio
+[ComVisible (true)]
+[Guid (PackageConsts.LanguageServiceGuid)]
+class MSBuildLanguageService : AbstractLanguageService<MSBuildEditorVisualStudioPackage, MSBuildLanguageService>, IVsFormatFilterProvider
 {
-	[ComVisible (true)]
-	[Guid (PackageConsts.LanguageServiceGuid)]
-	public class MSBuildLanguageService : LanguageBase
+	public MSBuildLanguageService (MSBuildEditorVisualStudioPackage package) : base (package) { }
+
+	protected override string LanguageName => PackageConsts.LanguageServiceName;
+
+	protected override string ContentTypeName => MSBuildContentType.Name;
+
+	public override Guid LanguageServiceId => PackageGuids.LanguageService;
+
+	FormatFilter[] formatFilters = new[] {
+		new FormatFilter ("MSBuild File", MSBuildFileExtension.All)
+	};
+
+	readonly record struct FormatFilter (string name, params string[] extensions)
 	{
-		public override string Name => PackageConsts.LanguageServiceName;
+	}
 
-		public override string[] FileExtensions { get; } = new[] {
-			MSBuildFileExtension.targets,
-			MSBuildFileExtension.props,
-			MSBuildFileExtension.tasks,
-			MSBuildFileExtension.overridetasks,
-			MSBuildFileExtension.csproj,
-			MSBuildFileExtension.vbproj,
-			MSBuildFileExtension.fsproj,
-			MSBuildFileExtension.xproj,
-			MSBuildFileExtension.vcxproj,
-			MSBuildFileExtension.proj,
-			MSBuildFileExtension.user
-		};
+	int IVsFormatFilterProvider.GetFormatFilterList (out string pbstrFilterList)
+	{
+		var sb = new StringBuilder ();
+		foreach (var filter in formatFilters) {
+			sb.Append (filter.name);
+			sb.Append ("' (");
+			bool first = true;
+			foreach (var ext in filter.extensions) {
+				if (!first) {
+					sb.Append (", ");
+				}
+				first = false;
+				sb.Append ("*");
+				sb.Append (ext);
+			}
+			sb.Append (")\n");
 
-		public MSBuildLanguageService (object site) : base (site) { }
-
-		public override void SetDefaultPreferences (LanguagePreferences preferences)
-		{
-			preferences.EnableMatchBraces = true;
-			preferences.EnableShowMatchingBrace = true;
-			preferences.EnableMatchBracesAtCaret = true;
-			preferences.HighlightMatchingBraceFlags = _HighlightMatchingBraceFlags.HMB_USERECTANGLEBRACES;
-
-			preferences.EnableCodeSense = false;
-			preferences.EnableAsyncCompletion = true;
-			preferences.EnableQuickInfo = true;
-
-			preferences.AutoOutlining = false;
-			preferences.ShowNavigationBar = false;
-
-			preferences.IndentSize = 2;
-			preferences.IndentStyle = IndentingStyle.Smart;
-			preferences.TabSize = 2;
-			preferences.InsertTabs = false;
-
-			preferences.WordWrap = false;
-			preferences.WordWrapGlyphs = true;
+			first = true;
+			foreach (var ext in filter.extensions) {
+				if (!first) {
+					sb.Append (";");
+				}
+				first = false;
+				sb.Append ("*");
+				sb.Append (ext);
+			}
+			sb.Append ("\n");
 		}
+
+		pbstrFilterList = sb.ToString ();
+
+		return VSConstants.S_OK;
+	}
+
+	int IVsFormatFilterProvider.CurFileExtensionFormat (string bstrFileName, out uint pdwExtnIndex)
+	{
+		for (uint filterIndex = 0; filterIndex < formatFilters.Length; filterIndex++) {
+			var filter = formatFilters[filterIndex];
+			foreach (var ext in filter.extensions) {
+				if (bstrFileName.EndsWith (ext, StringComparison.OrdinalIgnoreCase)) {
+					pdwExtnIndex = filterIndex;
+					return VSConstants.S_OK;
+				}
+			}
+		}
+
+		pdwExtnIndex = 0;
+		return VSConstants.E_FAIL;
+	}
+
+	int IVsFormatFilterProvider.QueryInvalidEncoding (uint format, out string pbstrMessage)
+	{
+		pbstrMessage = null;
+		return VSConstants.S_FALSE;
 	}
 }

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/PackageConsts.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/PackageConsts.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace MonoDevelop.MSBuild.Editor.VisualStudio
 {
 	class PackageConsts
@@ -9,6 +11,7 @@ namespace MonoDevelop.MSBuild.Editor.VisualStudio
 		public const string PackageVersion = ThisAssembly.AssemblyInformationalVersion;
 
 		public const string LanguageServiceGuid = "111E2ECB-9E5F-4945-9D21-D4E5368D620B";
+		public const string EditorFactoryGuid = "4C9BC7A2-907A-44AA-99EA-D1B57B1A20F8";
 
 		public const string LanguageServiceName = "MSBuild";
 		public const string LanguageServiceKey = @"Languages\Language Services\" + LanguageServiceName;
@@ -50,5 +53,13 @@ namespace MonoDevelop.MSBuild.Editor.VisualStudio
 		/// </summary>
 		public const int TelemetryOptionsPageKeywords = 114;
 		public const string GeneralOptionsPageKeywordsStr = "#114";
+	}
+
+	class PackageGuids
+	{
+		public static readonly Guid Package = new(PackageConsts.PackageGuid);
+		public static readonly Guid LanguageService = new(PackageConsts.LanguageServiceGuid);
+		public static readonly Guid EditorFactory = new(PackageConsts.EditorFactoryGuid);
+		public static readonly Guid TelemetryOptionsPage = new(PackageConsts.TelemetryOptionsPageGuid);
 	}
 }

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Helpers/Contract.InterpolatedStringHandlers.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Helpers/Contract.InterpolatedStringHandlers.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+#pragma warning disable IDE0060 // Remove unused parameter - https://github.com/dotnet/roslyn/issues/58168
+
+namespace Roslyn.Utilities
+{
+    internal static partial class Contract
+    {
+        [InterpolatedStringHandler]
+        public readonly struct ThrowIfTrueInterpolatedStringHandler
+        {
+            private readonly StringBuilder _stringBuilder;
+
+            public ThrowIfTrueInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool success)
+            {
+                _stringBuilder = condition ? new StringBuilder(capacity: literalLength) : null!;
+                success = condition;
+            }
+
+            public void AppendLiteral(string value) => _stringBuilder.Append(value);
+
+            public void AppendFormatted<T>(T value) => _stringBuilder.Append(value?.ToString());
+
+            public string GetFormattedText() => _stringBuilder.ToString();
+        }
+
+        [InterpolatedStringHandler]
+        public readonly struct ThrowIfFalseInterpolatedStringHandler
+        {
+            private readonly StringBuilder _stringBuilder;
+
+            public ThrowIfFalseInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool success)
+            {
+                _stringBuilder = condition ? null! : new StringBuilder(capacity: literalLength);
+                success = !condition;
+            }
+
+            public void AppendLiteral(string value) => _stringBuilder.Append(value);
+
+            public void AppendFormatted<T>(T value) => _stringBuilder.Append(value?.ToString());
+
+            public string GetFormattedText() => _stringBuilder.ToString();
+        }
+
+        [InterpolatedStringHandler]
+        public readonly struct ThrowIfNullInterpolatedStringHandler<T>
+        {
+            private readonly StringBuilder _stringBuilder;
+
+            public ThrowIfNullInterpolatedStringHandler(int literalLength, int formattedCount, T? value, out bool success)
+            {
+                _stringBuilder = value is null ? new StringBuilder(capacity: literalLength) : null!;
+                success = value is null;
+            }
+
+            public void AppendLiteral(string value) => _stringBuilder.Append(value);
+
+            public void AppendFormatted<T2>(T2 value) => _stringBuilder.Append(value?.ToString());
+
+            public string GetFormattedText() => _stringBuilder.ToString();
+        }
+    }
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Helpers/Contract.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Helpers/Contract.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Roslyn.Utilities
+{
+    internal static partial class Contract
+    {
+        // Guidance on inlining:
+        // ThrowXxx methods are used heavily across the code base. 
+        // Inline their implementation of condition checking but don't inline the code that is only executed on failure.
+        // This approach makes the common path efficient (both execution time and code size) 
+        // while keeping the rarely executed code in a separate method.
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is null.  This method executes in
+        /// all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNull<T>([NotNull] T value, [CallerLineNumber] int lineNumber = 0) where T : class?
+        {
+            if (value is null)
+            {
+                Fail("Unexpected null", lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is null.  This method executes in
+        /// all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNull<T>([NotNull] T? value, [CallerLineNumber] int lineNumber = 0) where T : struct
+        {
+            if (value is null)
+            {
+                Fail("Unexpected null", lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is null.  This method executes in
+        /// all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNull<T>([NotNull] T value, string message, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (value is null)
+            {
+                Fail(message, lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is null.  This method executes in
+        /// all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNull<T>([NotNull] T value, [InterpolatedStringHandlerArgument("value")] ThrowIfNullInterpolatedStringHandler<T> message, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (value is null)
+            {
+                Fail(message.GetFormattedText(), lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is false.  This method executes
+        /// in all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (!condition)
+            {
+                Fail("Unexpected false", lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is false.  This method executes
+        /// in all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, string message, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (!condition)
+            {
+                Fail(message, lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is false.  This method executes
+        /// in all builds
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfFalse([DoesNotReturnIf(parameterValue: false)] bool condition, [InterpolatedStringHandlerArgument("condition")] ThrowIfFalseInterpolatedStringHandler message, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (!condition)
+            {
+                Fail(message.GetFormattedText(), lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is true. This method executes in
+        /// all builds.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (condition)
+            {
+                Fail("Unexpected true", lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is true. This method executes in
+        /// all builds.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition, string message, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (condition)
+            {
+                Fail(message, lineNumber);
+            }
+        }
+
+        /// <summary>
+        /// Throws a non-accessible exception if the provided value is true. This method executes in
+        /// all builds.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfTrue([DoesNotReturnIf(parameterValue: true)] bool condition, [InterpolatedStringHandlerArgument("condition")] ThrowIfTrueInterpolatedStringHandler message, [CallerLineNumber] int lineNumber = 0)
+        {
+            if (condition)
+            {
+                Fail(message.GetFormattedText(), lineNumber);
+            }
+        }
+
+        [DebuggerHidden]
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void Fail(string message = "Unexpected", [CallerLineNumber] int lineNumber = 0)
+            => throw new InvalidOperationException($"{message} - line {lineNumber}");
+    }
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Helpers/InterpolatedStringHandlerArgumentAttribute.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Helpers/InterpolatedStringHandlerArgumentAttribute.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET6_0_OR_GREATER
+
+using System.Runtime.CompilerServices;
+
+#pragma warning disable RS0016 // Add public types and members to the declared API (this is a supporting forwarder for an internal polyfill API)
+[assembly: TypeForwardedTo(typeof(InterpolatedStringHandlerArgumentAttribute))]
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
+#else
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Indicates which arguments to a method involving an interpolated string handler should be passed to that handler.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    internal sealed class InterpolatedStringHandlerArgumentAttribute : Attribute
+    {
+        /// <summary>Initializes a new instance of the <see cref="InterpolatedStringHandlerArgumentAttribute"/> class.</summary>
+        /// <param name="argument">The name of the argument that should be passed to the handler.</param>
+        /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
+        public InterpolatedStringHandlerArgumentAttribute(string argument) => Arguments = new string[] { argument };
+        /// <summary>Initializes a new instance of the <see cref="InterpolatedStringHandlerArgumentAttribute"/> class.</summary>
+        /// <param name="arguments">The names of the arguments that should be passed to the handler.</param>
+        /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
+        public InterpolatedStringHandlerArgumentAttribute(params string[] arguments) => Arguments = arguments;
+        /// <summary>Gets the names of the arguments that should be passed to the handler.</summary>
+        /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
+        public string[] Arguments { get; }
+    }
+}
+
+#endif

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Helpers/InterpolatedStringHandlerAttribute.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Helpers/InterpolatedStringHandlerAttribute.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET6_0_OR_GREATER
+
+using System.Runtime.CompilerServices;
+
+#pragma warning disable RS0016 // Add public types and members to the declared API (this is a supporting forwarder for an internal polyfill API)
+[assembly: TypeForwardedTo(typeof(InterpolatedStringHandlerAttribute))]
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
+#else
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Indicates the attributed type is to be used as an interpolated string handler.</summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+    internal sealed class InterpolatedStringHandlerAttribute : Attribute
+    {
+        /// <summary>Initializes the <see cref="InterpolatedStringHandlerAttribute"/>.</summary>
+        public InterpolatedStringHandlerAttribute() { }
+    }
+}
+
+#endif

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/ComAggregate.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/ComAggregate.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
+{
+	internal static class ComAggregate
+	{
+		/// <summary>
+		/// This method creates a native COM object that aggregates the passed in managed object.
+		/// The reason we need to do this is to enable legacy managed code that expects managed casts
+		/// expressions to perform a QI on the COM object wrapped by an RCW. These clients are relying
+		/// on the fact that COM type equality is based on GUID, whereas type equality is identity in 
+		/// the managed world.
+		/// Example: IMethodXML is defined many times throughout VS and used by many managed clients
+		///          dealing with CodeFunction objects. If the CodeFunction objects they deal with are
+		///          direct references to managed objects, then casts operations are managed casts
+		///          (as opposed to QI calls), and they fail, since the managed type for IMethodXML
+		///          have different identity (since they are defined in different assemblies). The QI
+		///          works, since under the hood, the casts operations are converted to QI with 
+		///          a GUID which is shared between all these types.
+		///          The solution to this is to return to these managed clients a native object,
+		///          which wraps the managed implementation of these interface using aggregation.
+		///          This means the interfaces will be obtained through QI, while the implementation
+		///          will be forwarded to the managed implementation.
+		/// </summary>
+		internal static object CreateAggregatedObject (object managedObject)
+			=> WrapperPolicy.CreateAggregatedObject (managedObject);
+
+		/// <summary>
+		/// Return the RCW for the native IComWrapperFixed instance aggregating "managedObject"
+		/// if there is one. Return "null" if "managedObject" is not aggregated.
+		/// </summary>
+		internal static IComWrapperFixed? TryGetWrapper (object managedObject)
+			=> WrapperPolicy.TryGetWrapper (managedObject);
+
+		internal static T GetManagedObject<T> (object value) where T : class
+		{
+			Contract.ThrowIfNull (value, "value");
+
+			if (value is IComWrapperFixed wrapper) {
+				return GetManagedObject<T> (wrapper);
+			}
+
+			Debug.Assert (value is T, "Why are you casting an object to an reference type it doesn't support?");
+			return (T)value;
+		}
+
+		internal static T GetManagedObject<T> (IComWrapperFixed comWrapper) where T : class
+		{
+			Contract.ThrowIfNull (comWrapper, "comWrapper");
+
+			var handle = GCHandle.FromIntPtr (comWrapper.GCHandlePtr);
+			var target = handle.Target;
+
+			Contract.ThrowIfNull (target, "target");
+			Debug.Assert (target is T, "Why are you casting an object to an reference type it doesn't support?");
+			return (T)target;
+		}
+
+		internal static T? TryGetManagedObject<T> (object? value) where T : class
+		{
+			if (value is IComWrapperFixed wrapper) {
+				return TryGetManagedObject<T> (wrapper);
+			}
+
+			return value as T;
+		}
+
+		internal static T? TryGetManagedObject<T> (IComWrapperFixed comWrapper) where T : class
+		{
+			if (comWrapper == null) {
+				return null;
+			}
+
+			var handle = GCHandle.FromIntPtr (comWrapper.GCHandlePtr);
+			return handle.Target as T;
+		}
+	}
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/ComEventSink.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/ComEventSink.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using Microsoft.VisualStudio.OLE.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal sealed class ComEventSink
+    {
+        public static ComEventSink Advise<T>(object obj, T sink) where T : class
+        {
+            if (!typeof(T).IsInterface)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (obj is not IConnectionPointContainer connectionPointContainer)
+            {
+                throw new ArgumentException("Not an IConnectionPointContainer", nameof(obj));
+            }
+
+            connectionPointContainer.FindConnectionPoint(typeof(T).GUID, out var connectionPoint);
+            if (connectionPoint == null)
+            {
+                throw new InvalidOperationException("Could not find connection point for " + typeof(T).FullName);
+            }
+
+            connectionPoint.Advise(sink, out var cookie);
+
+            return new ComEventSink(connectionPoint, cookie);
+        }
+
+        private readonly IConnectionPoint _connectionPoint;
+        private readonly uint _cookie;
+        private bool _unadvised;
+
+        public ComEventSink(IConnectionPoint connectionPoint, uint cookie)
+        {
+            _connectionPoint = connectionPoint;
+            _cookie = cookie;
+        }
+
+        public void Unadvise()
+        {
+            if (_unadvised)
+            {
+                throw new InvalidOperationException("Already unadvised.");
+            }
+
+            _connectionPoint.Unadvise(_cookie);
+            _unadvised = true;
+        }
+    }
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/IComWrapperFixed.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/IComWrapperFixed.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
+{
+#pragma warning disable RS0030 // Do not used banned APIs
+    /// <inheritdoc cref="IComWrapper"/>
+#pragma warning restore RS0030 // Do not used banned APIs
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("CBD71F2C-6BC5-4932-B851-B93EB3151386")]
+    internal interface IComWrapperFixed
+    {
+        /// <inheritdoc cref="IComWrapper.GCHandlePtr"/>
+        /// <returns>An <see cref="IntPtr"/> which can be passed to <see cref="GCHandle.FromIntPtr(IntPtr)"/> to obtain
+        /// a handle to the managed object.</returns>
+        /// <remarks>
+        /// The original native interface defined this as
+        /// <see href="https://docs.microsoft.com/en-us/windows/win32/winprog64/avoiding-polymorphism"><c>INT_PTR</c></see>
+        /// when it was actually being implemented as <see cref="IntPtr"/> for callers within the current process. This
+        /// definition more faithfully reflects the original code.
+        /// </remarks>
+        [ComAliasName("VsShell.INT_PTR")]
+        IntPtr GCHandlePtr { get; }
+    }
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/WrapperPolicy.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/WrapperPolicy.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
+{
+    internal static class WrapperPolicy
+    {
+        /// <summary>
+        /// Factory object for creating IComWrapperFixed instances.
+        /// Internal and not readonly so that unit tests can provide an alternative implementation.
+        /// </summary>
+        internal static IComWrapperFactory s_ComWrapperFactory =
+            (IComWrapperFactory)PackageUtilities.CreateInstance(typeof(IComWrapperFactory).GUID);
+
+        internal static object CreateAggregatedObject(object managedObject) => s_ComWrapperFactory.CreateAggregatedObject(managedObject);
+
+        /// <summary>
+        /// Return the RCW for the native IComWrapperFixed instance aggregating "managedObject"
+        /// if there is one. Return "null" if "managedObject" is not aggregated.
+        /// </summary>
+        internal static IComWrapperFixed? TryGetWrapper(object managedObject)
+        {
+            // Note: this method should be "return managedObject" once we can get rid of this while IComWrapperFixed
+            // business.
+
+            // This force the CLR to retrieve the "outer" object of "managedObject"
+            // if "managedObject" has been aggregated
+            var ptr = Marshal.GetIUnknownForObject(managedObject);
+            try
+            {
+                // This asks the CLR to return the RCW corresponding to the
+                // aggregator object.
+                var wrapper = Marshal.GetObjectForIUnknown(ptr);
+
+                // The aggregator (if there is one) implement IComWrapperFixed!
+                return wrapper as IComWrapperFixed;
+            }
+            finally
+            {
+                Marshal.Release(ptr);
+            }
+        }
+    }
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractEditorFactory.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractEditorFactory.cs
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Utilities;
+
+using Roslyn.Utilities;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+	/// <summary>
+	/// The base class of both the Roslyn editor factories.
+	/// </summary>
+	internal abstract class AbstractEditorFactory : IVsEditorFactory, IVsEditorFactory4
+	{
+		private readonly IComponentModel _componentModel;
+		private Microsoft.VisualStudio.OLE.Interop.IServiceProvider? _oleServiceProvider;
+		private bool _encoding;
+
+		protected AbstractEditorFactory (IComponentModel componentModel)
+			=> _componentModel = componentModel;
+
+		protected abstract string ContentTypeName { get; }
+		protected abstract string LanguageName { get; }
+
+		public void SetEncoding (bool value)
+			=> _encoding = value;
+
+		int IVsEditorFactory.Close ()
+			=> VSConstants.S_OK;
+
+		public int CreateEditorInstance (
+			uint grfCreateDoc,
+			string pszMkDocument,
+			string? pszPhysicalView,
+			IVsHierarchy vsHierarchy,
+			uint itemid,
+			IntPtr punkDocDataExisting,
+			out IntPtr ppunkDocView,
+			out IntPtr ppunkDocData,
+			out string pbstrEditorCaption,
+			out Guid pguidCmdUI,
+			out int pgrfCDW)
+		{
+			Contract.ThrowIfNull (_oleServiceProvider);
+
+			ppunkDocView = IntPtr.Zero;
+			ppunkDocData = IntPtr.Zero;
+			pbstrEditorCaption = string.Empty;
+			pguidCmdUI = Guid.Empty;
+			pgrfCDW = 0;
+
+			var physicalView = pszPhysicalView ?? "Code";
+			IVsTextBuffer? textBuffer = null;
+
+			// Is this document already open? If so, let's see if it's a IVsTextBuffer we should re-use. This allows us
+			// to properly handle multiple windows open for the same document.
+			if (punkDocDataExisting != IntPtr.Zero) {
+				var docDataExisting = Marshal.GetObjectForIUnknown (punkDocDataExisting);
+
+				textBuffer = docDataExisting as IVsTextBuffer;
+
+				if (textBuffer == null) {
+					// We are incompatible with the existing doc data
+					return VSConstants.VS_E_INCOMPATIBLEDOCDATA;
+				}
+			}
+
+			var editorAdaptersFactoryService = _componentModel.GetService<IVsEditorAdaptersFactoryService> ();
+
+			// Do we need to create a text buffer?
+			if (textBuffer == null) {
+				textBuffer = (IVsTextBuffer)GetDocumentData (grfCreateDoc, pszMkDocument, vsHierarchy, itemid);
+				Contract.ThrowIfNull (textBuffer, $"Failed to get document data for {pszMkDocument}");
+			}
+
+			// If the text buffer is marked as read-only, ensure that the padlock icon is displayed
+			// next the new window's title and that [Read Only] is appended to title.
+			var readOnlyStatus = READONLYSTATUS.ROSTATUS_NotReadOnly;
+			if (ErrorHandler.Succeeded (textBuffer.GetStateFlags (out var textBufferFlags)) &&
+				0 != (textBufferFlags & ((uint)BUFFERSTATEFLAGS.BSF_FILESYS_READONLY | (uint)BUFFERSTATEFLAGS.BSF_USER_READONLY))) {
+				readOnlyStatus = READONLYSTATUS.ROSTATUS_ReadOnly;
+			}
+
+			switch (physicalView) {
+
+			case "Code":
+
+				var codeWindow = editorAdaptersFactoryService.CreateVsCodeWindowAdapter (_oleServiceProvider);
+				codeWindow.SetBuffer ((IVsTextLines)textBuffer);
+
+				codeWindow.GetEditorCaption (readOnlyStatus, out pbstrEditorCaption);
+
+				ppunkDocView = Marshal.GetIUnknownForObject (codeWindow);
+				pguidCmdUI = VSConstants.GUID_TextEditorFactory;
+
+				break;
+
+			default:
+
+				return VSConstants.E_INVALIDARG;
+			}
+
+			ppunkDocData = Marshal.GetIUnknownForObject (textBuffer);
+
+			return VSConstants.S_OK;
+		}
+
+		public object GetDocumentData (uint grfCreate, string pszMkDocument, IVsHierarchy pHier, uint itemid)
+		{
+			Contract.ThrowIfNull (_oleServiceProvider);
+			var editorAdaptersFactoryService = _componentModel.GetService<IVsEditorAdaptersFactoryService> ();
+			var contentTypeRegistryService = _componentModel.GetService<IContentTypeRegistryService> ();
+			var contentType = contentTypeRegistryService.GetContentType (ContentTypeName);
+			var textBuffer = editorAdaptersFactoryService.CreateVsTextBufferAdapter (_oleServiceProvider, contentType);
+
+			if (_encoding) {
+				if (textBuffer is IVsUserData userData) {
+					// The editor shims require that the boxed value when setting the PromptOnLoad flag is a uint
+					var hresult = userData.SetData (
+						VSConstants.VsTextBufferUserDataGuid.VsBufferEncodingPromptOnLoad_guid,
+						(uint)__PROMPTONLOADFLAGS.codepagePrompt);
+
+					Marshal.ThrowExceptionForHR (hresult);
+				}
+			}
+
+			return textBuffer;
+		}
+
+		public object GetDocumentView (uint grfCreate, string pszPhysicalView, IVsHierarchy pHier, IntPtr punkDocData, uint itemid)
+		{
+			// There is no scenario need currently to implement this method.
+			throw new NotImplementedException ();
+		}
+
+		public string GetEditorCaption (string pszMkDocument, string pszPhysicalView, IVsHierarchy pHier, IntPtr punkDocData, out Guid pguidCmdUI)
+		{
+			// It is not possible to get this information without initializing the designer.
+			// There is no other scenario need currently to implement this method.
+			throw new NotImplementedException ();
+		}
+
+		public bool ShouldDeferUntilIntellisenseIsReady (uint grfCreate, string pszMkDocument, string pszPhysicalView) => false;
+
+		public int MapLogicalView (ref Guid rguidLogicalView, out string? pbstrPhysicalView)
+		{
+			pbstrPhysicalView = null;
+
+			if (rguidLogicalView == VSConstants.LOGVIEWID.Primary_guid ||
+				rguidLogicalView == VSConstants.LOGVIEWID.Debugging_guid ||
+				rguidLogicalView == VSConstants.LOGVIEWID.Code_guid ||
+				rguidLogicalView == VSConstants.LOGVIEWID.TextView_guid) {
+				return VSConstants.S_OK;
+			} else {
+				return VSConstants.E_NOTIMPL;
+			}
+		}
+
+		int IVsEditorFactory.SetSite (Microsoft.VisualStudio.OLE.Interop.IServiceProvider psp)
+		{
+			_oleServiceProvider = psp;
+			return VSConstants.S_OK;
+		}
+	}
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService.IVsAutoOutliningClient.cs.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService.IVsAutoOutliningClient.cs.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
+{
+    internal abstract partial class AbstractLanguageService : IVsAutoOutliningClient
+    {
+        public int QueryWaitForAutoOutliningCallback(out int fWait)
+        {
+            // Normally, the editor automatically loads outlining information immediately. By saying we want to wait, we get to
+            // control the load point during our view setup.
+            fWait = 1;
+            return VSConstants.S_OK;
+        }
+    }
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.IVsLanguageInfo.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.IVsLanguageInfo.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
+{
+	internal abstract partial class AbstractLanguageService<TPackage, TLanguageService> : IVsLanguageInfo
+	{
+		public int GetCodeWindowManager (IVsCodeWindow pCodeWin, out IVsCodeWindowManager ppCodeWinMgr)
+		{
+			ppCodeWinMgr = new VsCodeWindowManager ((TLanguageService)this, pCodeWin);
+
+			return VSConstants.S_OK;
+		}
+
+		public int GetColorizer (IVsTextLines pBuffer, out IVsColorizer ppColorizer)
+		{
+			ppColorizer = null;
+
+			return VSConstants.E_NOTIMPL;
+		}
+
+		public int GetFileExtensions (out string pbstrExtensions)
+		{
+			pbstrExtensions = null;
+
+			return VSConstants.E_NOTIMPL;
+		}
+
+		public int GetLanguageName (out string bstrName)
+		{
+			bstrName = LanguageName;
+
+			return VSConstants.S_OK;
+		}
+	}
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
+{
+	internal abstract partial class AbstractLanguageService<TPackage, TLanguageService>
+	{
+		internal class VsCodeWindowManager : IVsCodeWindowManager, IVsCodeWindowEvents
+		{
+			private readonly TLanguageService _languageService;
+			private readonly IVsCodeWindow _codeWindow;
+			private readonly ComEventSink _sink;
+
+			private IDisposable? _navigationBarController;
+			private IVsDropdownBarClient? _dropdownBarClient;
+
+			public VsCodeWindowManager (TLanguageService languageService, IVsCodeWindow codeWindow)
+			{
+				_languageService = languageService;
+				_codeWindow = codeWindow;
+
+				_sink = ComEventSink.Advise<IVsCodeWindowEvents> (codeWindow, this);
+			}
+
+			private void SetupView (IVsTextView view)
+				=> _languageService.SetupNewTextView (view);
+
+			public int AddAdornments ()
+			{
+				int hr;
+				if (ErrorHandler.Failed (hr = _codeWindow.GetPrimaryView (out var primaryView))) {
+					Debug.Fail ("GetPrimaryView failed in IVsCodeWindowManager.AddAdornments");
+					return hr;
+				}
+
+				SetupView (primaryView);
+				if (ErrorHandler.Succeeded (_codeWindow.GetSecondaryView (out var secondaryView))) {
+					SetupView (secondaryView);
+				}
+
+				return VSConstants.S_OK;
+			}
+
+			public int OnCloseView (IVsTextView view)
+			{
+				return VSConstants.S_OK;
+			}
+
+			public int OnNewView (IVsTextView view)
+			{
+				SetupView (view);
+
+				return VSConstants.S_OK;
+			}
+
+			public int RemoveAdornments ()
+			{
+				_sink.Unadvise ();
+
+				return VSConstants.S_OK;
+			}
+		}
+	}
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
+{
+	internal abstract partial class AbstractLanguageService<TPackage, TLanguageService> : AbstractLanguageService
+        where TPackage : AbstractPackage<TPackage, TLanguageService>
+        where TLanguageService : AbstractLanguageService<TPackage, TLanguageService>
+    {
+        internal TPackage Package { get; }
+
+        // DevDiv 753309:
+        // We've redefined some VS interfaces that had incorrect PIAs. When 
+        // we interop with native parts of VS, they always QI, so everything
+        // works. However, Razor is now managed, but assumes that the C#
+        // language service is native. When setting breakpoints, they
+        // get the language service from its GUID and cast it to IVsLanguageDebugInfo.
+        // This would QI the native lang service. Since we're managed and
+        // we've redefined IVsLanguageDebugInfo, the cast
+        // fails. To work around this, we put the LS inside a ComAggregate object,
+        // which always force a QueryInterface and allow their cast to succeed.
+        // 
+        // This also fixes 752331, which is a similar problem with the 
+        // exception assistant.
+        internal object ComAggregate { get; private set; }
+
+        // Note: The lifetime for state in this class is carefully managed.  For every bit of state
+        // we set up, there is a corresponding tear down phase which deconstructs the state in the
+        // reverse order it was created in.
+        internal IVsEditorAdaptersFactoryService EditorAdaptersFactoryService { get; private set; }
+
+        /// <summary>
+        /// Whether or not we have been set up. This is set once everything is wired up and cleared once tear down has begun.
+        /// </summary>
+        /// <remarks>
+        /// We don't set this until we've completed setup. If something goes sideways during it, we will never register
+        /// with the shell and thus have a floating thing around that can't be safely shut down either. We're in a bad
+        /// state but trying to proceed will only make things worse.
+        /// </remarks>
+        private bool _isSetUp;
+
+        protected AbstractLanguageService(TPackage package)
+        {
+            Package = package;
+        }
+
+        public override IServiceProvider SystemServiceProvider
+            => Package;
+
+        /// <summary>
+        /// Setup and TearDown go in reverse order.
+        /// </summary>
+        internal void Setup()
+        {
+            this.ComAggregate = CreateComAggregate();
+
+            // First, acquire any services we need throughout our lifetime.
+            this.GetServices();
+
+            // TODO: Is the below access to component model required or can be removed?
+            _ = this.Package.ComponentModel;
+
+            // Start off a background task to prime some components we'll need for editing
+			/*
+            VsTaskLibraryHelper.CreateAndStartTask(VsTaskLibraryHelper.ServiceInstance, VsTaskRunContext.BackgroundThread,
+                () => PrimeLanguageServiceComponentsOnBackground());
+			*/
+
+            // Finally, once our connections are established, set up any initial state that we need.
+            // Note: we may be instantiated at any time (including when the IDE is already
+            // debugging).  We must not assume anything about our initial state and must instead
+            // query for all the information we need at this point.
+            this.Initialize();
+
+            _isSetUp = true;
+        }
+
+        private object CreateComAggregate()
+            => Interop.ComAggregate.CreateAggregatedObject(this);
+
+        internal void TearDown()
+        {
+            if (!_isSetUp)
+            {
+                throw new InvalidOperationException();
+            }
+
+            _isSetUp = false;
+            GC.SuppressFinalize(this);
+
+            this.Uninitialize();
+            this.RemoveServices();
+        }
+
+        ~AbstractLanguageService()
+        {
+            if (!Environment.HasShutdownStarted && _isSetUp)
+            {
+                throw new InvalidOperationException("TearDown not called!");
+            }
+        }
+
+        protected virtual void GetServices()
+        {
+            // This method should only contain calls to acquire services off of the component model
+            // or service providers.  Anything else which is more complicated should go in Initialize
+            // instead.
+            this.EditorAdaptersFactoryService = this.Package.ComponentModel.GetService<IVsEditorAdaptersFactoryService>();
+        }
+
+        protected virtual void RemoveServices()
+        {
+            this.EditorAdaptersFactoryService = null;
+        }
+
+        /// <summary>
+        /// Called right after we instantiate the language service.  Used to set up any internal
+        /// state we need.
+        /// 
+        /// Try to keep this method fairly clean.  Any complicated logic should go in methods called
+        /// from this one.  Initialize and Uninitialize go in reverse order 
+        /// </summary>
+        protected virtual void Initialize()
+        {
+			/*
+            InitializeLanguageDebugInfo();
+			*/
+		}
+
+		protected virtual void Uninitialize()
+        {
+			/*
+            UninitializeLanguageDebugInfo();
+			*/
+		}
+
+		protected abstract string ContentTypeName { get; }
+        protected abstract string LanguageName { get; }
+
+        protected virtual void SetupNewTextView(IVsTextView textView)
+        {
+			/*
+            Contract.ThrowIfNull(textView);
+
+            var wpfTextView = EditorAdaptersFactoryService.GetWpfTextView(textView);
+            Contract.ThrowIfNull(wpfTextView, "Could not get IWpfTextView for IVsTextView");
+
+            Debug.Assert(!wpfTextView.Properties.ContainsProperty(typeof(AbstractVsTextViewFilter)));
+
+            var workspace = Package.ComponentModel.GetService<VisualStudioWorkspace>();
+
+            // The lifetime of CommandFilter is married to the view
+            wpfTextView.GetOrCreateAutoClosingProperty(v =>
+                new StandaloneCommandFilter(
+                    v, Package.ComponentModel).AttachToVsTextView());
+			*/
+        }
+
+		/*
+        private void InitializeLanguageDebugInfo()
+            => this.LanguageDebugInfo = this.CreateLanguageDebugInfo();
+
+        protected abstract Guid DebuggerLanguageId { get; }
+
+        private VsLanguageDebugInfo CreateLanguageDebugInfo()
+        {
+            var workspace = this.Workspace;
+            var languageServices = workspace.Services.GetLanguageServices(RoslynLanguageName);
+
+            return new VsLanguageDebugInfo(
+                this.DebuggerLanguageId,
+                (TLanguageService)this,
+                languageServices,
+                this.Package.ComponentModel.GetService<IThreadingContext>(),
+                this.Package.ComponentModel.GetService<IUIThreadOperationExecutor>());
+        }
+
+        private void UninitializeLanguageDebugInfo()
+            => this.LanguageDebugInfo = null;*/
+    }
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractPackage.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractPackage.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
+{
+    internal abstract class AbstractPackage : AsyncPackage
+    {
+        private IComponentModel? _componentModel_doNotAccessDirectly;
+
+        internal IComponentModel ComponentModel
+        {
+            get
+            {
+                Assumes.Present(_componentModel_doNotAccessDirectly);
+                return _componentModel_doNotAccessDirectly;
+            }
+        }
+
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            _componentModel_doNotAccessDirectly = (IComponentModel)await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(true);
+            Assumes.Present(_componentModel_doNotAccessDirectly);
+        }
+
+        protected async Task LoadComponentsInUIContextOnceSolutionFullyLoadedAsync(CancellationToken cancellationToken)
+        {
+            // UIContexts can be "zombied" if UIContexts aren't supported because we're in a command line build or in other scenarios.
+            // Trying to await them will throw.
+            if (!KnownUIContexts.SolutionExistsAndFullyLoadedContext.IsZombie)
+            {
+                await KnownUIContexts.SolutionExistsAndFullyLoadedContext;
+                await LoadComponentsAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        protected abstract Task LoadComponentsAsync(CancellationToken cancellationToken);
+    }
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractPackage`2.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractPackage`2.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
+{
+	internal abstract partial class AbstractPackage<TPackage, TLanguageService> : AbstractPackage
+        where TPackage : AbstractPackage<TPackage, TLanguageService>
+        where TLanguageService : AbstractLanguageService<TPackage, TLanguageService>
+    {
+        private TLanguageService _languageService;
+
+        protected AbstractPackage()
+        {
+        }
+
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            await base.InitializeAsync(cancellationToken, progress).ConfigureAwait(true);
+
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var shell = (IVsShell7)await GetServiceAsync(typeof(SVsShell)).ConfigureAwait(true);
+            var solution = (IVsSolution)await GetServiceAsync(typeof(SVsSolution)).ConfigureAwait(true);
+            cancellationToken.ThrowIfCancellationRequested();
+            Assumes.Present(shell);
+            Assumes.Present(solution);
+
+            foreach (var editorFactory in CreateEditorFactories())
+            {
+                RegisterEditorFactory(editorFactory);
+            }
+
+            RegisterLanguageService(typeof(TLanguageService), async ct =>
+            {
+                await JoinableTaskFactory.SwitchToMainThreadAsync(ct);
+
+                // Create the language service, tell it to set itself up, then store it in a field
+                // so we can notify it that it's time to clean up.
+                _languageService = CreateLanguageService();
+                _languageService.Setup();
+                return _languageService.ComAggregate;
+            });
+
+            LoadComponentsInUIContextOnceSolutionFullyLoadedAsync(cancellationToken).Forget();
+        }
+
+        protected override async Task LoadComponentsAsync(CancellationToken cancellationToken)
+        {
+            // Do the MEF loads and initialization in the BG explicitly.
+            await TaskScheduler.Default;
+        }
+
+        protected abstract IEnumerable<IVsEditorFactory> CreateEditorFactories();
+        protected abstract TLanguageService CreateLanguageService();
+
+        protected void RegisterService<T>(Func<CancellationToken, Task<T>> serviceCreator)
+            => AddService(typeof(T), async (container, cancellationToken, type) => await serviceCreator(cancellationToken).ConfigureAwait(true), promote: true);
+
+        // When registering a language service, we need to take its ComAggregate wrapper.
+        protected void RegisterLanguageService(Type t, Func<CancellationToken, Task<object>> serviceCreator)
+            => AddService(t, async (container, cancellationToken, type) => await serviceCreator(cancellationToken).ConfigureAwait(true), promote: true);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // If we've created the language service then tell it it's time to clean itself up now.
+                if (_languageService != null)
+                {
+                    _languageService.TearDown();
+                    _languageService = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/LanguageService.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/LanguageService.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
+{
+	internal abstract partial class AbstractLanguageService
+	{
+		public abstract Guid LanguageServiceId { get; }
+		public abstract IServiceProvider SystemServiceProvider { get; }
+	}
+}

--- a/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
+++ b/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
@@ -245,7 +245,7 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 			var doc = context.doc;
 			var spine = context.spine;
 
-			if (rr?.ElementSyntax != null) {
+			if (rr?.ElementSyntax is MSBuildElementSyntax elementSyntax && elementSyntax.ValueKind != MSBuildValueKind.Nothing) {
 				var reason = ConvertReason (trigger.Reason, trigger.Character);
 				if (reason.HasValue && IsPossibleExpressionCompletionContext (spine)) {
 					string expression = spine.GetIncompleteValue (triggerLocation.Snapshot);

--- a/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
+++ b/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
@@ -209,7 +209,7 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 			//we don't care need a real document here we're doing very basic resolution for triggering
 			var spine = GetSpineParser (triggerLocation);
 			var rr = MSBuildResolver.Resolve (spine.Clone (), triggerLocation.Snapshot.GetTextSource (), MSBuildRootDocument.Empty, null, Logger, token);
-			if (rr?.ElementSyntax is MSBuildElementSyntax elementSyntax && elementSyntax.ValueKind != MSBuildValueKind.Nothing) {
+			if (rr?.ElementSyntax is MSBuildElementSyntax elementSyntax && (rr.Attribute is not null || elementSyntax.ValueKind != MSBuildValueKind.Nothing)) {
 				var reason = ConvertReason (trigger.Reason, trigger.Character);
 				if (reason.HasValue && IsPossibleExpressionCompletionContext (spine)) {
 					string expression = spine.GetIncompleteValue (triggerLocation.Snapshot);

--- a/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
+++ b/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
@@ -595,24 +595,29 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 		IEnumerable<CompletionItem> GetLcidCompletions ()
 		{
 			var imageEl = provider.DisplayElementFactory.GetImageElement (KnownImages.Constant);
-			foreach (var culture in System.Globalization.CultureInfo.GetCultures (System.Globalization.CultureTypes.AllCultures)) {
+			foreach (var culture in CultureHelper.GetAllCultures ()) {
 				string cultureLcid = culture.LCID.ToString ();
 				string displayName = culture.DisplayName;
-				// display the culture name so ppl can just type it instead of looking up the LCID
-				string displayText = $"{cultureLcid} - ({displayName})";
+				// add the culture name to the filter text so ppl can just type the actual language/country instead of looking up the code
 				string filterText = $"{cultureLcid} {displayName}";
-				yield return new CompletionItem (displayText, this, imageEl, ImmutableArray<CompletionFilter>.Empty, string.Empty, cultureLcid, cultureLcid, filterText, ImmutableArray<ImageElement>.Empty);
+				var item = new CompletionItem (cultureLcid, this, imageEl, ImmutableArray<CompletionFilter>.Empty, displayName, cultureLcid, cultureLcid, filterText, ImmutableArray<ImageElement>.Empty);
+				item.Properties.AddProperty (typeof (ISymbol), CultureHelper.CreateLcidSymbol (culture));
+				yield return item;
 			}
 		}
 
 		IEnumerable<CompletionItem> GetCultureCompletions ()
 		{
 			var imageEl = provider.DisplayElementFactory.GetImageElement (KnownImages.Constant);
-			foreach (var culture in System.Globalization.CultureInfo.GetCultures (System.Globalization.CultureTypes.AllCultures)) {
+			foreach (var culture in CultureHelper.GetAllCultures ()) {
 				string cultureName = culture.Name;
+				if (string.IsNullOrEmpty (cultureName)) {
+					continue;
+				}
+				// add the culture name to the filter text so ppl can just type the actual language/country instead of looking up the code
 				string filterText = $"{culture.Name} {culture.DisplayName}";
-				var item = new CompletionItem (cultureName, this, imageEl, ImmutableArray<CompletionFilter>.Empty, string.Empty, cultureName, cultureName, cultureName, ImmutableArray<ImageElement>.Empty);
-				item.AddDocumentation (culture.DisplayName);
+				var item = new CompletionItem (culture.Name, this, imageEl, ImmutableArray<CompletionFilter>.Empty, culture.DisplayName, cultureName, cultureName, filterText, ImmutableArray<ImageElement>.Empty);
+				item.Properties.AddProperty (typeof (ISymbol), CultureHelper.CreateCultureSymbol (culture));
 				yield return item;
 			}
 		}

--- a/MonoDevelop.MSBuild.Editor/MSBuildBackgroundParser.cs
+++ b/MonoDevelop.MSBuild.Editor/MSBuildBackgroundParser.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+# nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,7 +23,7 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 	{
 		readonly ILogger logger;
 		readonly MSBuildParserProvider provider;
-		string filepath;
+		string? filePath;
 
 		//FIXME: move this to a lower priority BackgroundProcessor
 		MSBuildAnalyzerDriver analyzerDriver;
@@ -34,7 +36,7 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 			XmlParser.ParseCompleted += XmlParseCompleted;
 
 			if (buffer.Properties.TryGetProperty<ITextDocument> (typeof (ITextDocument), out var doc)) {
-				filepath = doc.FilePath;
+				filePath = doc.FilePath;
 				doc.FileActionOccurred += OnFileAction;
 			}
 
@@ -49,7 +51,7 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 		void OnFileAction (object sender, TextDocumentFileActionEventArgs e)
 		{
 			if (e.FileActionType == FileActionTypes.DocumentRenamed) {
-				filepath = ((ITextDocument)sender).FilePath;
+				filePath = ((ITextDocument)sender).FilePath;
 			}
 		}
 
@@ -71,7 +73,7 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 				try {
 					doc = MSBuildRootDocument.Parse (
 						input.TextSnapshot.GetTextSource (),
-						filepath,
+						filePath,
 						oldDoc,
 						provider.SchemaProvider,
 						provider.MSBuildEnvironment,
@@ -86,10 +88,6 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 				catch (Exception ex) when (!(ex is OperationCanceledException && token.IsCancellationRequested)) {
 					LogUnhandledParserError (logger, ex);
 					doc = MSBuildRootDocument.Empty;
-				}
-				// for some reason the VS debugger thinks cancellation exceptions aren't handled?
-				catch (OperationCanceledException) when (token.IsCancellationRequested) {
-					return null;
 				}
 
 				return new MSBuildParseResult (doc, doc.Diagnostics, input.TextSnapshot);
@@ -113,6 +111,6 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 			ParseCompleted?.Invoke (this, new ParseCompletedEventArgs<MSBuildParseResult> (output, output.Snapshot));
 		}
 
-		public event EventHandler<ParseCompletedEventArgs<MSBuildParseResult>> ParseCompleted;
+		public event EventHandler<ParseCompletedEventArgs<MSBuildParseResult>>? ParseCompleted;
 	}
 }

--- a/MonoDevelop.MSBuild.Tests.Editor/Completion/MSBuildCompletionTests.cs
+++ b/MonoDevelop.MSBuild.Tests.Editor/Completion/MSBuildCompletionTests.cs
@@ -34,10 +34,10 @@ namespace MonoDevelop.MSBuild.Tests.Editor.Completion
 
 			result.AssertItemCount (11);
 
-			result.AssertContains ("PropertyGroup");
-			result.AssertContains ("Choose");
-			result.AssertContains ("/Project");
-			result.AssertContains ("!--");
+			result.AssertContains ("<PropertyGroup");
+			result.AssertContains ("<Choose");
+			result.AssertContains ("</Project");
+			result.AssertContains ("<!--");
 		}
 
 		[Test]
@@ -48,11 +48,11 @@ namespace MonoDevelop.MSBuild.Tests.Editor.Completion
 
 			result.AssertItemCount (5);
 
-			result.AssertContains ("Foo");
-			result.AssertContains ("Bar");
-			result.AssertContains ("/ItemGroup");
-			result.AssertContains ("/Project");
-			result.AssertContains ("!--");
+			result.AssertContains ("<Foo");
+			result.AssertContains ("<Bar");
+			result.AssertContains ("</ItemGroup");
+			result.AssertContains ("</Project");
+			result.AssertContains ("<!--");
 		}
 
 		[Test]
@@ -63,7 +63,7 @@ namespace MonoDevelop.MSBuild.Tests.Editor.Completion
 
 			result.AssertItemCount (5);
 
-			result.AssertContains ("Bar");
+			result.AssertContains ("<Bar");
 		}
 
 		[Test]

--- a/MonoDevelop.MSBuild/Language/CoreDiagnostics.cs
+++ b/MonoDevelop.MSBuild/Language/CoreDiagnostics.cs
@@ -354,15 +354,15 @@ namespace MonoDevelop.MSBuild.Language
 		public const string InvalidCultureId = nameof (InvalidCulture);
 		public static MSBuildDiagnosticDescriptor InvalidCulture = new MSBuildDiagnosticDescriptor (
 			InvalidLcidId,
-			"Invalid LCID",
+			"Invalid culture name",
 			"The value '{0}' is not a valid culture name",
 			MSBuildDiagnosticSeverity.Error);
 
 		public const string UnknownCultureId = nameof (UnknownCulture);
 		public static MSBuildDiagnosticDescriptor UnknownCulture = new MSBuildDiagnosticDescriptor (
 			UnknownLcidId,
-			"Unknown LCID",
-			"The value '{0}' is not a known culture",
+			"Unknown culture name",
+			"The value '{0}' is not a known culture name",
 			MSBuildDiagnosticSeverity.Warning);
 
 		public static MSBuildDiagnosticDescriptor InvalidUrl = new MSBuildDiagnosticDescriptor (

--- a/MonoDevelop.MSBuild/Language/CultureHelper.cs
+++ b/MonoDevelop.MSBuild/Language/CultureHelper.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+using MonoDevelop.MSBuild.Language.Typesystem;
+
+namespace MonoDevelop.MSBuild.Language;
+
+// centralizing culture stuff here will allow eventually supporting intellisense
+// for cultures that aren't available on the current system
+class CultureHelper
+{
+	public static bool IsValidCultureName (string cultureName) => IsValidBcp47Name (cultureName);
+
+	public static bool IsKnownCulture (string cultureName)
+	{
+		try {
+			var culture = CultureInfo.GetCultureInfo (cultureName);
+			return IsKnownCulture (culture);
+		} catch (CultureNotFoundException) {
+		}
+		return false;
+	}
+
+	public static bool IsValidLcid (string value, out int lcid) => int.TryParse (value, out lcid) && lcid > 0;
+
+	public static bool IsKnownLcid (int lcid)
+	{
+		try {
+			var culture = CultureInfo.GetCultureInfo (lcid);
+			return HasKnownLcid (culture);
+		} catch (CultureNotFoundException) {
+		}
+		return false;
+	}
+
+	public static bool TryGetLcidSymbol (string lcidString, [NotNullWhen (true)] out ISymbol? lcidSymbol)
+	{
+		lcidSymbol = null;
+		return int.TryParse (lcidString, out int lcid) && TryGetLcidSymbol (lcid, out lcidSymbol);
+	}
+
+	// 4096 is the "not found" lcid
+	static bool HasKnownLcid (CultureInfo culture) => culture.LCID != 4096;
+
+	static bool IsKnownCulture (CultureInfo culture) => !culture.EnglishName.StartsWith ("Unknown", System.StringComparison.Ordinal);
+
+	public static bool TryGetLcidSymbol (int lcid, [NotNullWhen (true)] out ISymbol? lcidSymbol)
+	{
+		try {
+			var culture = CultureInfo.GetCultureInfo (lcid);
+			if (HasKnownLcid (culture)) {
+				lcidSymbol = CreateLcidSymbol (culture);
+				return true;
+			}
+		} catch (CultureNotFoundException) {
+		}
+		lcidSymbol = null;
+		return false;
+	}
+
+	public static bool TryGetCultureSymbol (string cultureName, [NotNullWhen (true)] out ISymbol? cultureSymbol)
+	{
+		try {
+			var culture = CultureInfo.GetCultureInfo (cultureName);
+			if (IsKnownCulture (culture)) {
+				cultureSymbol = CreateCultureSymbol (culture);
+				return true;
+			}
+		} catch (CultureNotFoundException) {
+		}
+		cultureSymbol = null;
+		return false;
+	}
+
+	public static ISymbol CreateLcidSymbol (CultureInfo culture) => new ConstantSymbol (culture.LCID.ToString (), $"The LCID of the {culture.DisplayName} culture", MSBuildValueKind.Lcid);
+
+	public static ISymbol CreateCultureSymbol (CultureInfo culture) => new ConstantSymbol (culture.Name, $"The name of the {culture.DisplayName} culture", MSBuildValueKind.Culture);
+
+	internal static IEnumerable<CultureInfo> GetAllCultures () => CultureInfo.GetCultures (CultureTypes.AllCultures);
+
+	// validate form of IETF BCP 47 language tag
+	// TODO: this currently only validates the primary subtag and region subtag. anything else will cause an error.
+	static bool IsValidBcp47Name (string name)
+	{
+		int index = 0;
+		bool isValid;
+
+		// primary language subtag: two letters, three letters, for 5-8 letters
+		int primaryTagLength = TryConsumeBasicLatinLetters ();
+		if (!(primaryTagLength == 2 || primaryTagLength == 3 || (primaryTagLength >= 5 && primaryTagLength <= 8))) {
+			return false;
+		}
+		if (IsEndOrNonDash ()) {
+			return isValid;
+		}
+
+		// skip: 0-3 extended language subtags, each 3 letters
+		// skip: optional script subtag, 4 letters
+
+		// optional region subtag, 2 letters, or 3 digits
+		int regionSubtagLetters = TryConsumeBasicLatinLetters ();
+		if (regionSubtagLetters == 2) {
+			if (IsEndOrNonDash ()) {
+				return isValid;
+			}
+		} else if (regionSubtagLetters != 0) {
+			return false;
+		}
+
+		int regionSubtagNumbers = TryConsumeNumbers ();
+		if (regionSubtagNumbers == 3) {
+			if (IsEndOrNonDash ()) {
+				return isValid;
+			}
+		} else if (regionSubtagLetters != 0) {
+			return false;
+		}
+
+		return index >= name.Length;
+
+		// skip: optional variant subtags, each 5-8 letters, or 4 characters starting with a digit
+		// skip: optional extension subtags, each 1 letter (except x) followed by 1 or more subtags of 2-8 characters
+		// skip: optional private-use subtag, x followed by 1 or more subtags of 1-8 characters
+
+		static bool IsBasicLatinLetterChar (char c) => (c >= 'A' && c <= 'X') || (c >= 'a' && c <= 'z');
+		static bool IsNumberChar (char c) => c >= '0' && c <= '9';
+
+		int TryConsumeBasicLatinLetters ()
+		{
+			int consumed = 0;
+			while (index < name.Length && IsBasicLatinLetterChar (name[index])) {
+				consumed++;
+				index++;
+			}
+			return consumed;
+		}
+
+		int TryConsumeNumbers ()
+		{
+			int consumed = 0;
+			while (index < name.Length && IsNumberChar (name[index])) {
+				consumed++;
+				index++;
+			}
+			return consumed;
+		}
+
+		bool ConsumeDash ()
+		{
+			if (index < name.Length && name[index] == '-') {
+				index++;
+				return true;
+			}
+			return false;
+		}
+
+		bool IsEndOrNonDash ()
+		{
+			if (index == name.Length) {
+				isValid = true;
+				return true;
+			}
+			if (ConsumeDash ()) {
+				isValid = true;
+				return false;
+			}
+			isValid = false;
+			return true;
+		}
+	}
+}

--- a/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
@@ -606,30 +606,17 @@ namespace MonoDevelop.MSBuild.Language
 				break;
 				*/
 			case MSBuildValueKind.Lcid:
-				if (int.TryParse (value, out int lcid) && lcid > 0) {
-					try {
-						CultureInfo.GetCultureInfo (lcid);
-					} catch (CultureNotFoundException) {
-						AddErrorWithArgs (CoreDiagnostics.UnknownLcid, value);
-					}
-				} else {
+				if (!CultureHelper.IsValidLcid (value, out int lcid)) {
 					AddErrorWithArgs (CoreDiagnostics.InvalidLcid, value);
+				} else if (!CultureHelper.IsKnownLcid (lcid)) {
+					AddErrorWithArgs (CoreDiagnostics.UnknownLcid, value);
 				}
 				break;
 			case MSBuildValueKind.Culture:
-				static bool IsAsciiLetter (char c) => (c >= 48 && c <= 57) || (c >= 65 && c <= 90);
-				static bool IsValidCultureName (string name) =>
-					name.Length >= 2 && IsAsciiLetter (name[0]) && IsAsciiLetter (name[1])
-					&& (name.Length == 2 || (name.Length == 5 && name[2] == '-' && IsAsciiLetter (name[3]) && IsAsciiLetter (name[4])));
-
-				if (IsValidCultureName (value)) {
-					try {
-						CultureInfo.GetCultureInfo(value);
-					} catch (CultureNotFoundException) {
-						AddErrorWithArgs (CoreDiagnostics.UnknownCulture, value);
-					}
-				} else {
+				if (!CultureHelper.IsValidCultureName (value)) {
 					AddErrorWithArgs (CoreDiagnostics.InvalidCulture, value);
+				} else if (!CultureHelper.IsKnownCulture (value)) {
+					AddErrorWithArgs (CoreDiagnostics.UnknownCulture, value);
 				}
 				break;
 			case MSBuildValueKind.TargetFramework:

--- a/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
@@ -472,6 +472,12 @@ namespace MonoDevelop.MSBuild.Language
 					ImmutableDictionary<string, object>.Empty.Add ("Name", info.Name),
 					DescriptionFormatter.GetKindNoun (info),
 					info.Name);
+				} else {
+					foreach (var listVal in list.Nodes) {
+						if (listVal is ExpressionText listValText) {
+							VisitPureLiteral (info, kind.WithoutModifiers (), listValText.GetUnescapedValue (), listValText.Offset);
+						}
+					}
 				}
 				if (!allowExpressions) {
 					var expr = list.Nodes.FirstOrDefault (n => !(n is ExpressionText));
@@ -480,7 +486,7 @@ namespace MonoDevelop.MSBuild.Language
 					}
 				}
 			} else if (node is ExpressionText lit) {
-				VisitPureLiteral (info, kind, lit.GetUnescapedValue (), lit.Offset);
+				VisitPureLiteral (info, kind.WithoutModifiers (), lit.GetUnescapedValue (), lit.Offset);
 			} else {
 				if (!allowExpressions) {
 					AddExpressionWarning (node);

--- a/MonoDevelop.MSBuild/Language/MSBuildResolver.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildResolver.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 
@@ -348,21 +347,15 @@ namespace MonoDevelop.MSBuild.Language
 					}
 					return;
 				case MSBuildValueKind.Lcid:
-					if (int.TryParse (value, out int lcid)) {
-						try {
-							var culture = CultureInfo.GetCultureInfo (lcid);
-							rr.ReferenceKind = MSBuildReferenceKind.KnownValue;
-							rr.Reference = new ConstantSymbol (value, culture.DisplayName, MSBuildValueKind.Lcid);
-						} catch {
-						}
-					}
-					return;
-				case MSBuildValueKind.Culture:
-					try {
-						var culture = CultureInfo.GetCultureInfo (value);
+					if (CultureHelper.TryGetLcidSymbol (value, out ISymbol lcidSymbol)) {
 						rr.ReferenceKind = MSBuildReferenceKind.KnownValue;
-						rr.Reference = new ConstantSymbol (value, culture.DisplayName, MSBuildValueKind.Culture);
-					} catch {
+						rr.Reference = lcidSymbol;
+					}
+					break;
+				case MSBuildValueKind.Culture:
+					if (CultureHelper.TryGetCultureSymbol (value, out ISymbol cultureSymbol)) {
+						rr.ReferenceKind = MSBuildReferenceKind.KnownValue;
+						rr.Reference = cultureSymbol;
 					}
 					return;
 				}

--- a/MonoDevelop.MSBuild/MSBuildFileExtension.cs
+++ b/MonoDevelop.MSBuild/MSBuildFileExtension.cs
@@ -25,5 +25,7 @@ namespace MonoDevelop.MSBuild
 		public const string vcxproj = ".vcxproj";
 		public const string proj = ".proj";
 		public const string user = ".user";
+
+		public static readonly string[] All = new[] { targets, props, tasks, overridetasks, csproj, vbproj, fsproj, xproj, vcxproj, proj, user };
 	}
 }

--- a/MonoDevelop.MSBuild/Schema/MSBuildCompletionExtensions.cs
+++ b/MonoDevelop.MSBuild/Schema/MSBuildCompletionExtensions.cs
@@ -448,7 +448,7 @@ namespace MonoDevelop.MSBuild.Schema
 				return null;
 			}
 
-			if (rr.AttributeName != null) {
+			if (rr.AttributeName is not null && rr.AttributeSyntax is not null) {
 				return schemas.GetAttributeInfo (rr.AttributeSyntax, rr.ElementName, rr.AttributeName);
 			}
 


### PR DESCRIPTION
The MSBuild editor uses modern editor APIs and replies on `Microsoft.VisualStudio.Editor.Implementation.CommandHandlerServiceAdapter` to displatch VS commands into the editor infrastructure.

The default `Microsoft.VisualStudio.Package.LanguageService` base class (and the derived `LanguageBase` in Community Toolkit) implements a ton of stuff we don't need, which causes `Microsoft.VisualStudio.Package.ViewFilter` to
get wired up.

`ViewFilter` then intercepts the following commands (and more) and causes them not to reach `CommandHandlerServiceAdapter`:

* `VsCommands2K.SHOWMEMBERLIST`
* `VsCommands2K.COMPLETEWORD`
* `VsCommands2K.QUICKINFO`

As a result, things like using Ctrl-Space to trigger completion don't work.

To fix this, instead use a copy of the `AbstractLanguageService`2` from Roslyn. As we're no longer using `LanguageBase`, we also need a separate editor factory.