### PR TITLE
Fix / committing <!-- in completion

### DIFF
--- a/MonoDevelop.MSBuild.Tests.Editor/Completion/MSBuildCommitTests.cs
+++ b/MonoDevelop.MSBuild.Tests.Editor/Completion/MSBuildCommitTests.cs
@@ -36,5 +36,23 @@ namespace MonoDevelop.MSBuild.Tests.Editor.Completion
 				"<Fo>Tr\n",
 				"<Project><PropertyGroup><Foo>True$</Foo>"
 			);
+
+		[Test]
+		public Task CommitClosingTagAtEof ()
+			=> TestTypeCommands (
+				"ClosingTag.csproj",
+				"<Project>\n  <PropertyGroup>\n    <foo>hello</foo>\n  $",
+				"</Prop\n",
+				"<Project>\n  <PropertyGroup>\n    <foo>hello</foo>\n  </PropertyGroup>$"
+			);
+
+		[Test]
+		public Task CommitClosingTag ()
+			=> TestTypeCommands (
+				"ClosingTag.csproj",
+				"<Project>\n  <PropertyGroup>\n    <foo>hello</foo>\n  $\n</Project>\n",
+				"</Prop\n",
+				"<Project>\n  <PropertyGroup>\n    <foo>hello</foo>\n  </PropertyGroup>$\n</Project>\n"
+			);
 	}
 }


### PR DESCRIPTION
This problem showed up in VS but not in the tests. Apparently the editor has changed its behavior since the editor version we use in the tests.