### PR TITLE
F12 for properties and items

### DIFF
--- a/MonoDevelop.MSBuild.Editor/Navigation/MSBuildNavigationService.cs
+++ b/MonoDevelop.MSBuild.Editor/Navigation/MSBuildNavigationService.cs
@@ -215,6 +215,31 @@ namespace MonoDevelop.MSBuild.Editor.Navigation
 		async Task FindReferencesAsync (ITextBuffer buffer, MSBuildResolveResult reference, ILogger logger)
 		{
 			var referenceName = reference.GetReferenceDisplayName ();
+
+			string searchTitle = reference.ReferenceKind switch {
+				MSBuildReferenceKind.Item => $"Item '{referenceName}' references",
+				MSBuildReferenceKind.Property => $"Property '{referenceName}' references",
+				MSBuildReferenceKind.Metadata => $"Metadata '{referenceName}' references",
+				MSBuildReferenceKind.Task => $"Task '{referenceName}' references",
+				MSBuildReferenceKind.TaskParameter => $"Task parameter '{referenceName}' references",
+				MSBuildReferenceKind.Keyword => $"Keyword '{referenceName}' references",
+				MSBuildReferenceKind.Target => $"Target '{referenceName}' references",
+				MSBuildReferenceKind.KnownValue => $"Value '{referenceName}' references",
+				MSBuildReferenceKind.NuGetID => $"NuGet package '{referenceName}' references",
+				MSBuildReferenceKind.TargetFramework => $"Target framework '{referenceName}' references",
+				MSBuildReferenceKind.ItemFunction => $"Item function '{referenceName}' references",
+				MSBuildReferenceKind.PropertyFunction => $"Property function '{referenceName}' references",
+				MSBuildReferenceKind.StaticPropertyFunction => $"Static '{referenceName}' references",
+				MSBuildReferenceKind.ClassName => $"Class '{referenceName}' references",
+				MSBuildReferenceKind.Enum => $"Enum '{referenceName}' references",
+				MSBuildReferenceKind.ConditionFunction => $"Condition function '{referenceName}' references",
+				MSBuildReferenceKind.FileOrFolder => $"Path '{referenceName}' references",
+				MSBuildReferenceKind.TargetFrameworkIdentifier => $"TargetFrameworkIdentifier '{referenceName}' references",
+				MSBuildReferenceKind.TargetFrameworkVersion => $"TargetFrameworkVersion '{referenceName}' references",
+				MSBuildReferenceKind.TargetFrameworkProfile => $"TargetFrameworkProfile '{referenceName}' references",
+				_ => logger.LogUnhandledCaseAndReturnDefaultValue ($"'{referenceName}' references", reference.ReferenceKind)
+			};
+
 			var searchCtx = Presenter.StartSearch ($"'{referenceName}' references", referenceName, true);
 
 			try {
@@ -227,7 +252,7 @@ namespace MonoDevelop.MSBuild.Editor.Navigation
 
 		async Task FindTargetDefinitions (string targetName, ITextBuffer buffer)
 		{
-			var searchCtx = Presenter.StartSearch ($"'{targetName}' definitions", targetName, true);
+			var searchCtx = Presenter.StartSearch ($"Target '{targetName}' definitions", targetName, true);
 
 			try {
 				await FindReferences (searchCtx, (doc, text, logger, reporter) => new MSBuildTargetDefinitionCollector (doc, text, logger, targetName, reporter), buffer);

--- a/MonoDevelop.MSBuild.Editor/Navigation/MSBuildNavigationService.cs
+++ b/MonoDevelop.MSBuild.Editor/Navigation/MSBuildNavigationService.cs
@@ -263,7 +263,7 @@ namespace MonoDevelop.MSBuild.Editor.Navigation
 			await searchCtx.OnCompletedAsync ();
 		}
 
-		delegate MSBuildReferenceCollector ReferenceCollectorFactory (MSBuildDocument doc, ITextSource textSource, ILogger logger, Action<(int Offset, int Length, ReferenceUsage Usage)> reportResult);
+		delegate MSBuildReferenceCollector ReferenceCollectorFactory (MSBuildDocument doc, ITextSource textSource, ILogger logger, FindReferencesReporter reportResult);
 
 		/// <remarks>
 		/// this does not need a cancellation token because it creates UI that handles cancellation
@@ -312,7 +312,7 @@ namespace MonoDevelop.MSBuild.Editor.Navigation
 					var progress = Interlocked.Increment (ref jobsCompleted);
 					await searchCtx.ReportProgressAsync (progress, jobs.Count);
 
-					void ReportResult ((int Offset, int Length, ReferenceUsage Usage) result)
+					void ReportResult (FindReferencesResult result)
 					{
 						var line = job.TextSource.Snapshot.GetLineFromPosition (result.Offset);
 						var col = result.Offset - line.Start.Position;

--- a/MonoDevelop.MSBuild.Tests.Editor/MSBuildFindReferencesTests.cs
+++ b/MonoDevelop.MSBuild.Tests.Editor/MSBuildFindReferencesTests.cs
@@ -22,7 +22,7 @@ namespace MonoDevelop.MSBuild.Tests
 	[TestFixture]
 	class MSBuildFindReferencesTests : MSBuildDocumentTest
 	{
-		List<(int Offset, int Length, ReferenceUsage Usage)> FindReferences (string docString, MSBuildReferenceKind kind, object reference, MSBuildSchema schema = null, [CallerMemberName] string testMethodName = null)
+		List<FindReferencesResult> FindReferences (string docString, MSBuildReferenceKind kind, object reference, MSBuildSchema schema = null, [CallerMemberName] string testMethodName = null)
 		{
 			var textDoc = new StringTextSource (docString);
 
@@ -40,7 +40,7 @@ namespace MonoDevelop.MSBuild.Tests
 
 			var functionTypeProvider = new RoslynFunctionTypeProvider (null, parseContext.Logger);
 
-			var results = new List<(int Offset, int Length, ReferenceUsage Usage)> ();
+			var results = new List<FindReferencesResult> ();
 			var collector = MSBuildReferenceCollector.Create (
 				doc, textDoc,logger,
 				new MSBuildResolver.MSBuildMutableResolveResult {
@@ -54,14 +54,14 @@ namespace MonoDevelop.MSBuild.Tests
 
 		void AssertLocations (
 			string doc, string expectedValue,
-			List<(int Offset, int Length, ReferenceUsage Usage)> actual,
+			List<FindReferencesResult> actual,
 			params (int Offset, int Length, ReferenceUsage Usage)[] expected
 			)
 			=> AssertLocations (doc, actual, expected.Select (e => (expectedValue, e.Offset, e.Length, e.Usage)).ToArray ());
 
 		void AssertLocations (
 			string doc,
-			List<(int Offset, int Length, ReferenceUsage Usage)> actual,
+			List<FindReferencesResult> actual,
 			params (string expectedValue, int Offset, int Length, ReferenceUsage Usage)[] expected)
 		{
 			if (actual.Count != expected.Length) {

--- a/MonoDevelop.MSBuild/Language/CoreDiagnostics.cs
+++ b/MonoDevelop.MSBuild/Language/CoreDiagnostics.cs
@@ -470,6 +470,13 @@ namespace MonoDevelop.MSBuild.Language
 			"The value `{0}` is not a valid suffixed version format",
 			MSBuildDiagnosticSeverity.Error);
 
+		public const string InvalidNuGetVersionExpression_Id = nameof (InvalidNuGetVersionExpression);
+		public static readonly MSBuildDiagnosticDescriptor InvalidNuGetVersionExpression = new (
+			InvalidNuGetVersionExpression_Id,
+			"Invalid NuGet version expression",
+			"The value `{0}` is not a valid NuGet version or version expression.",
+			MSBuildDiagnosticSeverity.Error);
+
 		public const string InvalidClrNamespace_Id = nameof (InvalidClrNamespace);
 		public static readonly MSBuildDiagnosticDescriptor InvalidClrNamespace = new (
 			InvalidClrNamespace_Id,

--- a/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
@@ -233,7 +233,7 @@ namespace MonoDevelop.MSBuild.Language
 			}
 		}
 
-		IEnumerable<(string id, TextSpan span)> SplitSdkValue (int offset, string value)
+		static IEnumerable<(string id, TextSpan span)> SplitSdkValue (int offset, string value)
 		{
 			int start = 0, end;
 			while ((end = value.IndexOf (';', start)) > -1) {
@@ -243,7 +243,7 @@ namespace MonoDevelop.MSBuild.Language
 			end = value.Length;
 			yield return MakeResult ();
 
-			TextSpan CreateSpan (int s, int e) => new TextSpan (offset + s, offset + e);
+			TextSpan CreateSpan (int s, int e) => TextSpan.FromBounds (offset + s, offset + e);
 
 			(string id, TextSpan loc) MakeResult ()
 			{

--- a/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
@@ -684,7 +684,7 @@ namespace MonoDevelop.MSBuild.Language
 				break;
 			case MSBuildValueKind.NuGetVersion:
 				if (!NuGet.Versioning.VersionRange.TryParse (value, out _)) {
-					AddErrorWithArgs (CoreDiagnostics.InvalidVersionSuffixed, value);
+					AddErrorWithArgs (CoreDiagnostics.InvalidNuGetVersionExpression, value);
 				}
 				break;
 			case MSBuildValueKind.VersionSuffixed:

--- a/MonoDevelop.MSBuild/Language/MSBuildNavigation.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildNavigation.cs
@@ -88,6 +88,14 @@ namespace MonoDevelop.MSBuild.Language
 				}
 			}
 
+			if (rr.ReferenceKind == MSBuildReferenceKind.Item) {
+				return new MSBuildNavigationResult (MSBuildReferenceKind.Item, rr.GetItemReference (), rr.ReferenceOffset, rr.ReferenceLength);
+			}
+
+			if (rr.ReferenceKind == MSBuildReferenceKind.Property) {
+				return new MSBuildNavigationResult (MSBuildReferenceKind.Property, rr.GetPropertyReference (), rr.ReferenceOffset, rr.ReferenceLength);
+			}
+
 			if (rr.ReferenceKind == MSBuildReferenceKind.Target) {
 				return new MSBuildNavigationResult (MSBuildReferenceKind.Target, rr.GetTargetReference (), rr.ReferenceOffset, rr.ReferenceLength);
 			}

--- a/MonoDevelop.MSBuild/Language/References/MSBuildKnownValueReferenceCollector.cs
+++ b/MonoDevelop.MSBuild/Language/References/MSBuildKnownValueReferenceCollector.cs
@@ -26,7 +26,7 @@ class MSBuildKnownValueReferenceCollector : MSBuildReferenceCollector
 	readonly CustomTypeInfo? customType;
 	readonly bool isWarningCode;
 
-	public MSBuildKnownValueReferenceCollector (MSBuildDocument document, ITextSource textSource, ILogger logger, ITypedSymbol knownValue, Action<(int Offset, int Length, ReferenceUsage Usage)> reportResult)
+	public MSBuildKnownValueReferenceCollector (MSBuildDocument document, ITextSource textSource, ILogger logger, ITypedSymbol knownValue, FindReferencesReporter reportResult)
 		: base (document, textSource, logger, knownValue.Name, reportResult)
 	{
 		kind = knownValue.ValueKind;

--- a/MonoDevelop.MSBuild/Util/MSBuildLoggerExtensions.cs
+++ b/MonoDevelop.MSBuild/Util/MSBuildLoggerExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Runtime.CompilerServices;
+
+using Microsoft.Extensions.Logging;
+
+namespace MonoDevelop.MSBuild;
+
+// consider moving some of these down to the XML layer?
+static partial class MSBuildLoggerExtensions
+{
+	/// <summary>
+	/// Helper for switch expressions to log a message about missing cases when they can gracefully return a default value instead of throwing
+	/// </summary>
+	/// <remarks>This must be kept internal so that analyzers and fixes don't use it, as it does not sanitize the callsite for PII.</remarks>
+	internal static TReturn LogUnhandledCaseAndReturnDefaultValue<TReturn,TSwitchValue> (this ILogger logger, TReturn valueToReturn, TSwitchValue missingValue, [CallerMemberName] string methodName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = 0)
+	{
+		LogUnhandledCase(logger, missingValue, methodName, filePath, lineNumber);
+		return valueToReturn;
+	}
+
+	/// <remarks>This must be kept internal so that analyzers and fixes don't use it, as it does not sanitize the callsite for PII.</remarks>
+	[LoggerMessage (EventId = 0, Level = LogLevel.Warning, Message = "Unhandled case '{missingValue}' in method {methodName} at {filePath}:{lineNumber}'")]
+	static partial void LogUnhandledCase (ILogger logger, object missingValue, string methodName, string filePath, int lineNumber);
+}


### PR DESCRIPTION
For properties/items, there isn't a definition *per se*, but searching for places where they are written/assigned seems like a reasonable interpretation that makes F12 more useful.

Plus a few additional fixes, mainly also in navigation.