### PR TITLE
Extend ILLink schema

### DIFF
--- a/MonoDevelop.MSBuild/Schema/BuiltInSchema.cs
+++ b/MonoDevelop.MSBuild/Schema/BuiltInSchema.cs
@@ -44,6 +44,7 @@ static class BuiltInSchema
 		   BuiltInSchemaId.CSharpWarningCodes,
 		   BuiltInSchemaId.AnalyzerWarningCodes,
 		   BuiltInSchemaId.StyleRuleCodes], null, "Microsoft.CSharp.CurrentVersion.targets"),
+		([ BuiltInSchemaId.ILCompiler ], null, "Microsoft.NETCore.Native.targets"),
 		([ BuiltInSchemaId.ILLink ], null, "Microsoft.NET.ILLink.targets"),
 		([ BuiltInSchemaId.JavaScript ], "Microsoft.VisualStudio.JavaScript.Sdk", sdkTargets),
 		([ BuiltInSchemaId.NetSdk ], "Microsoft.NET.Sdk", sdkTargets),

--- a/MonoDevelop.MSBuild/Schema/BuiltInSchemaId.cs
+++ b/MonoDevelop.MSBuild/Schema/BuiltInSchemaId.cs
@@ -28,5 +28,6 @@ enum BuiltInSchemaId
 	ProjectSystemMps,
 	ProjectSystemCps,
 	GenerateAssemblyInfo,
-	ValidatePackage
+	ValidatePackage,
+	ILCompiler
 }

--- a/MonoDevelop.MSBuild/Schemas/ILCompiler.buildschema.json
+++ b/MonoDevelop.MSBuild/Schemas/ILCompiler.buildschema.json
@@ -1,0 +1,88 @@
+{
+  "license": "Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.",
+  // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/index.md
+  // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/interop.md
+  // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/optimizing.md
+  // based on https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md
+  // based on https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md
+  "properties": {
+    "IlcDumpGeneratedIL": {
+      "description": "Dump IL for method bodies the compiler generated on the fly into `ProjectName.il`.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcGenerateDgmlFile": {
+      "description": "Generates log files `ProjectName.codegen.dgml.xml` and `ProjectName.scan.dgml.xml` in DGML format.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcGenerateMapFile": {
+      "description": "Generates log files `ProjectName.map.xml` which describe layout of objects.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcGenerateMetadataLog": {
+      "description": "Enable generation of a native AoT compiler metadata log.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcGenerateMstatFile": {
+      "description": "Generates an `mstat` file which contains size information about types, methods and blobs emitted.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcInstructionSet": {
+      "description": "Specifies a set of CPU instruction sets to allow targeting newer instruction sets for better performance. Run `ilc --help` for the full list of available instruction sets.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md",
+      "type": "string"
+    },
+    "IlcMaxVectorTBitWidth": {
+      "description": "Specifies a different maximum bit width for `Vector<T>` types. The default is 16 or 32 bytes, depending on the underlying instruction sets supported.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md",
+      "type": "int"
+    },
+    "IlcSingleThreaded": {
+      "description": "Perform native AoT compilation on single thread.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "OptimizationPreference": {
+      "description": "When using Native AOT, specifies a general optimization goal for compilation instead of the blended default approach.",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/optimizing#optimize-for-size-or-speed",
+      "type": {
+        "values": {
+          "Size": "Instructs the publishing process to favor the size of the executable instead of other performance metrics.",
+          "Speed": "Instructs the publishing process to favor code execution speed."
+        }
+      }
+    }
+  },
+  "items": {
+    "DirectPInvoke": {
+      "description": "When using Native AOT, specifies that internal types and members are visible to the specified friend assemblies. These can be either a `<modulename>`, which enables direct calls for all entry points in a module, or `<modulename!entrypointname>`, which enables a direct call for the specific module and entry point only.",
+      "includeDescription": "module names or module-entrypoint name pairs",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#direct-pinvoke-calls"
+    },
+    "DirectPInvokeList": {
+      "description": "When using Native AOT, specifies a list of entry points in an external file.",
+      "type": "file", // .txt
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#direct-pinvoke-calls"
+    },
+    "LinkerArg": {
+      "description": "When using Native AOT, specifies additional flags to the native linker, such as for `link.exe` on Windows and clang/gcc on Linux.",
+      "includeDescription": "additional arguments",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#linking"
+    },
+    "NativeLibrary": {
+      "description": "When using Native AOT, specifies a native library to be statically linked into the binary. Must be a `.lib` file on Windows and a `.a` file on Unix-like systems.",
+      "type": "file", // .txt
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#linking"
+    }
+  }
+}

--- a/MonoDevelop.MSBuild/Schemas/ILLink.buildschema.json
+++ b/MonoDevelop.MSBuild/Schemas/ILLink.buildschema.json
@@ -2,11 +2,6 @@
   "license": "Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.",
   // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/trimming/trimming-options.md
   // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
-  // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/index.md
-  // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/interop.md
-  // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/optimizing.md
-  // based on https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md
-  // based on https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md
   "properties": {
     "PublishTrimmed": {
       "description": "Indicates whether the project should produce trimmed assembly images during publish.",
@@ -55,74 +50,6 @@
       "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-8-0#remove-symbols",
       "type": "bool",
       "defaultValue": "false"
-    },
-    "OptimizationPreference": {
-      "description": "Specifies a general optimization goal for native AoT compilation instead of the blended default approach.",
-      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/optimizing#optimize-for-size-or-speed",
-      "type": {
-        "values": {
-          "Size": "Instructs the publishing process to favor the size of the executable instead of other performance metrics.",
-          "Speed": "Instructs the publishing process to favor code execution speed."
-        }
-      }
-    },
-    "EnableSingleFileAnalyzer": {
-      "description": "Enables single-file analysis. Defaults to true when IsAotCompatible is set to true.",
-      "helpUrl": "https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1195",
-      "type": "bool",
-      "defaultValue": "false"
-    },
-    "EnableAotAnalyzer": {
-      "description": "Enables AoT analysis. Defaults to true when IsAotCompatible is set to true.",
-      "helpUrl": "https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1195",
-      "type": "bool",
-      "defaultValue": "false"
-    },
-    "IlcInstructionSet": {
-      "description": "Specifies a set of CPU instruction sets to allow targeting newer instruction sets for better performance. Run 'ilc --help' for the full list of available instruction sets.",
-      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md",
-      "type": "string"
-    },
-    "IlcMaxVectorTBitWidth": {
-      "description": "Specifies a different maximum bit width for Vector<T> types. The default is 16 or 32 bytes, depending on the underlying instruction sets supported.",
-      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md",
-      "type": "int"
-    },
-    "IlcGenerateMetadataLog": {
-      "description": "Enable generation of a native AoT compiler metadata log.",
-      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
-      "type": "bool",
-      "defaultValue": "false"
-    },
-    "IlcGenerateDgmlFile": {
-      "description": "Generates log files 'ProjectName.codegen.dgml.xml' and 'ProjectName.scan.dgml.xml' in DGML format.",
-      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
-      "type": "bool",
-      "defaultValue": "false"
-    },
-    "IlcGenerateMapFile": {
-      "description": "Generates log files 'ProjectName.map.xml' which describe layout of objects.",
-      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
-      "type": "bool",
-      "defaultValue": "false"
-    },
-    "IlcSingleThreaded": {
-      "description": "Perform native AoT compilation on single thread.",
-      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
-      "type": "bool",
-      "defaultValue": "false"
-    },
-    "IlcDumpGeneratedIL": {
-      "description": "Dump IL for method bodies the compiler generated on the fly into 'ProjectName.il'.",
-      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
-      "type": "bool",
-      "defaultValue": "false"
-    },
-    "IlcGenerateMstatFile": {
-      "description": "Generates an mstat file which contains size information about types, methods and blobs emitted.",
-      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
-      "type": "bool",
-      "defaultValue": "false"
     }
   },
   "items": {
@@ -145,26 +72,6 @@
       "description": "XML files that specify assemblies, types, and their members that should not be trimmed.",
       "type": "file", // .xml
       "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#root-descriptors"
-    },
-    "DirectPInvoke": {
-      "description": "Specifies that internal types and members are visible to the specified friend assemblies.",
-      "includeDescription": "Either <modulename>, which enables direct calls for all entry points in the module, or <modulename!entrypointname>, which enables a direct call for the specific module and entry point only.",
-      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#direct-pinvoke-calls"
-    },
-    "DirectPInvokeList": {
-      "description": "Specifies a list of entry points in an external file.",
-      "type": "file", // .txt
-      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#direct-pinvoke-calls"
-    },
-    "NativeLibrary": {
-      "description": "Specifies a .lib file on Windows and a .a file on Unix-like systems.",
-      "type": "file", // .txt
-      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#linking"
-    },
-    "LinkerArg": {
-      "description": "Specifies additional flags to the native linker.",
-      "includeDescription": "The flags to specify.",
-      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#linking"
     }
   },
   "types": {

--- a/MonoDevelop.MSBuild/Schemas/ILLink.buildschema.json
+++ b/MonoDevelop.MSBuild/Schemas/ILLink.buildschema.json
@@ -2,6 +2,11 @@
   "license": "Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.",
   // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/trimming/trimming-options.md
   // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/trimming/prepare-libraries-for-trimming.md
+  // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/index.md
+  // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/interop.md
+  // based on https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/optimizing.md
+  // based on https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md
+  // based on https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md
   "properties": {
     "PublishTrimmed": {
       "description": "Indicates whether the project should produce trimmed assembly images during publish.",
@@ -50,6 +55,74 @@
       "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-8-0#remove-symbols",
       "type": "bool",
       "defaultValue": "false"
+    },
+    "OptimizationPreference": {
+      "description": "Specifies a general optimization goal for native AoT compilation instead of the blended default approach.",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/optimizing#optimize-for-size-or-speed",
+      "type": {
+        "values": {
+          "Size": "Instructs the publishing process to favor the size of the executable instead of other performance metrics.",
+          "Speed": "Instructs the publishing process to favor code execution speed."
+        }
+      }
+    },
+    "EnableSingleFileAnalyzer": {
+      "description": "Enables single-file analysis. Defaults to true when IsAotCompatible is set to true.",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1195",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "EnableAotAnalyzer": {
+      "description": "Enables AoT analysis. Defaults to true when IsAotCompatible is set to true.",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1195",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcInstructionSet": {
+      "description": "Specifies a set of CPU instruction sets to allow targeting newer instruction sets for better performance. Run 'ilc --help' for the full list of available instruction sets.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md",
+      "type": "string"
+    },
+    "IlcMaxVectorTBitWidth": {
+      "description": "Specifies a different maximum bit width for Vector<T> types. The default is 16 or 32 bytes, depending on the underlying instruction sets supported.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md",
+      "type": "int"
+    },
+    "IlcGenerateMetadataLog": {
+      "description": "Enable generation of a native AoT compiler metadata log.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcGenerateDgmlFile": {
+      "description": "Generates log files 'ProjectName.codegen.dgml.xml' and 'ProjectName.scan.dgml.xml' in DGML format.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcGenerateMapFile": {
+      "description": "Generates log files 'ProjectName.map.xml' which describe layout of objects.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcSingleThreaded": {
+      "description": "Perform native AoT compilation on single thread.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcDumpGeneratedIL": {
+      "description": "Dump IL for method bodies the compiler generated on the fly into 'ProjectName.il'.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "IlcGenerateMstatFile": {
+      "description": "Generates an mstat file which contains size information about types, methods and blobs emitted.",
+      "helpUrl": "https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/troubleshooting.md",
+      "type": "bool",
+      "defaultValue": "false"
     }
   },
   "items": {
@@ -72,6 +145,26 @@
       "description": "XML files that specify assemblies, types, and their members that should not be trimmed.",
       "type": "file", // .xml
       "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#root-descriptors"
+    },
+    "DirectPInvoke": {
+      "description": "Specifies that internal types and members are visible to the specified friend assemblies.",
+      "includeDescription": "Either <modulename>, which enables direct calls for all entry points in the module, or <modulename!entrypointname>, which enables a direct call for the specific module and entry point only.",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#direct-pinvoke-calls"
+    },
+    "DirectPInvokeList": {
+      "description": "Specifies a list of entry points in an external file.",
+      "type": "file", // .txt
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#direct-pinvoke-calls"
+    },
+    "NativeLibrary": {
+      "description": "Specifies a .lib file on Windows and a .a file on Unix-like systems.",
+      "type": "file", // .txt
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#linking"
+    },
+    "LinkerArg": {
+      "description": "Specifies additional flags to the native linker.",
+      "includeDescription": "The flags to specify.",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot/interop#linking"
     }
   },
   "types": {
@@ -112,6 +205,7 @@
 | _AggressiveAttributeTrimming | System.AggressiveAttributeTrimming | When set to true, aggressively trims attributes to allow for the most size savings possible, even if it could result in runtime behavior changes |
 | JsonSerializerIsReflectionEnabledByDefault | System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault | When set to false, disables using reflection as the default contract resolver in System.Text.Json |
 | EnableGeneratedComInterfaceComImportInterop | System.Runtime.InteropServices.Marshalling.EnableGeneratedComInterfaceComImportInterop | When set to true, enables casting source-generated COM object wrappers to built-in COM-based COM interfaces. |
+| StackTraceSupport | Remove support for generating stack traces | |
 | _UseManagedNtlm | System.Net.Security.UseManagedNtlm | When set to true, uses built-in managed implementation of NTLM and SPNEGO algorithm for HTTP, SMTP authentication, and NegotiateAuthentication API instead of system provided GSSAPI implementation. |
 */
 }

--- a/MonoDevelop.MSBuild/Schemas/NetSdk.buildschema.json
+++ b/MonoDevelop.MSBuild/Schemas/NetSdk.buildschema.json
@@ -95,6 +95,18 @@
       "type": "bool",
       "helpUrl": "https://learn.microsoft.com/dotnet/core/deploying/native-aot#aot-compatibility-analyzers"
     },
+    "EnableSingleFileAnalyzer": {
+      "description": "Enables single-file analysis. Defaults to true when `IsAotCompatible` is set to true.",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1195",
+      "type": "bool",
+      "defaultValue": "false"
+    },
+    "EnableAotAnalyzer": {
+      "description": "Enables AoT analysis. Defaults to true when `IsAotCompatible` is set to true.",
+      "helpUrl": "https://learn.microsoft.com/dotnet/core/tools/sdk-errors/netsdk1195",
+      "type": "bool",
+      "defaultValue": "false"
+    },
     "DisableTransitiveProjectReferences": {
       "description": "When true, do not discover ProjectReference items representing projects referenced by this project's ProjectReferences. Applies only to projects using the .NET SDK.",
       "type": "bool"


### PR DESCRIPTION
Add additional ILLink properties and items related to native AoT.

Happy to move them to a different schema if needed (`ILCompiler`?), but there seemed to be lots of related concepts in this file already.

Resolves #205.
