### PR TITLE
Metadata tooltip fixes

### DIFF
--- a/MonoDevelop.MSBuild.Editor/DisplayElementFactory.cs
+++ b/MonoDevelop.MSBuild.Editor/DisplayElementFactory.cs
@@ -368,7 +368,7 @@ namespace MonoDevelop.MSBuild.Editor
 			case TargetInfo:
 				return isPrivate ? KnownImages.MSBuildTargetPrivate : KnownImages.MSBuildTarget;
 			case MetadataInfo:
-				return isPrivate ? KnownImages.MSBuildMetadata : KnownImages.MSBuildMetadataPrivate;
+				return isPrivate ? KnownImages.MSBuildMetadataPrivate : KnownImages.MSBuildMetadata;
 			case TaskInfo:
 				return KnownImages.MSBuildTask;
 			case ConstantSymbol:

--- a/MonoDevelop.MSBuild.Tests/MSBuildIdentifierTests.cs
+++ b/MonoDevelop.MSBuild.Tests/MSBuildIdentifierTests.cs
@@ -30,6 +30,35 @@ class MSBuildIdentifierTests
 		Assert.AreEqual (isValid, actual);
 	}
 
+	[TestCase ("IsFoo", "Is")]
+	[TestCase ("_IsFoo", "Is")]
+	[TestCase ("_HasFoo", "Has")]
+	[TestCase ("Foo", null)]
+	[TestCase ("_Foo", null)]
+	[TestCase ("__Foo", null)]
+	[TestCase (" Foo", null)]
+	public void TestGetPrefix (string identifier, string prefix)
+	{
+		bool success = MSBuildIdentifier.TryGetPrefix (identifier, out var actual);
+		Assert.AreEqual (prefix is not null, success);
+		Assert.AreEqual (prefix, actual);
+	}
+
+	[TestCase ("FooPath", "Path")]
+	[TestCase ("_FooEnabled", "Enabled")]
+	[TestCase ("_PineappleOn", "On")]
+	[TestCase ("Foo", null)]
+	[TestCase ("Foo_", null)]
+	[TestCase ("_Cat", null)]
+	[TestCase ("__Mouse_", null)]
+	[TestCase ("Walrus ", null)]
+	public void TestGetSuffix (string identifier, string suffix)
+	{
+		bool success = MSBuildIdentifier.TryGetSuffix (identifier, out var actual);
+		Assert.AreEqual (suffix is not null, success);
+		Assert.AreEqual (suffix, actual);
+	}
+
 	[TestCase ("Enable", MSBuildValueKind.Unknown)]
 	[TestCase ("EnableFoo", MSBuildValueKind.Bool)]
 	[TestCase ("_EnableFoo", MSBuildValueKind.Bool)]

--- a/MonoDevelop.MSBuild.Tests/MSBuildIdentifierTests.cs
+++ b/MonoDevelop.MSBuild.Tests/MSBuildIdentifierTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MonoDevelop.MSBuild.Language;
+using MonoDevelop.MSBuild.Language.Syntax;
+using MonoDevelop.MSBuild.Language.Typesystem;
+
+using NUnit.Framework;
+
+namespace MonoDevelop.MSBuild.Tests;
+
+[TestFixture]
+class MSBuildIdentifierTests
+{
+	[TestCase ("_FooBar", true)]
+	[TestCase ("FooBar", true)]
+	[TestCase ("fooBar", true)]
+	[TestCase ("foo", true)]
+	[TestCase ("Foo", true)]
+	[TestCase ("", false)]
+	[TestCase ("-FooBar", false)]
+	[TestCase (" FooBar", false)]
+	[TestCase ("FooBar ", false)]
+	[TestCase ("Foo Bar", false)]
+	[TestCase ("1Foo", false)]
+	[TestCase ("\"Foo", false)]
+	public void TestValidIdentifiers (string identifier, bool isValid)
+	{
+		bool actual = MSBuildIdentifier.IsValid (identifier);
+		Assert.AreEqual (isValid, actual);
+	}
+
+	[TestCase ("Enable", MSBuildValueKind.Unknown)]
+	[TestCase ("EnableFoo", MSBuildValueKind.Bool)]
+	[TestCase ("_EnableFoo", MSBuildValueKind.Bool)]
+	[TestCase ("DisableFoo", MSBuildValueKind.Bool)]
+	[TestCase ("RequireFoo", MSBuildValueKind.Bool)]
+	[TestCase ("UseFoo", MSBuildValueKind.Bool)]
+	[TestCase ("AllowFoo", MSBuildValueKind.Bool)]
+	[TestCase ("FooEnabled", MSBuildValueKind.Bool)]
+	[TestCase ("FooDisabled", MSBuildValueKind.Bool)]
+	[TestCase ("FooRequired", MSBuildValueKind.Bool)]
+	[TestCase ("RequiredFoo", MSBuildValueKind.Unknown)]
+	[TestCase ("FooDependsOn", MSBuildValueKind.TargetName | MSBuildValueKind.ListSemicolon)]
+	[TestCase ("FooPath", MSBuildValueKind.FileOrFolder)]
+	[TestCase ("FooPaths", MSBuildValueKind.FileOrFolder | MSBuildValueKind.ListSemicolon)]
+	[TestCase ("FooDirectory", MSBuildValueKind.Folder)]
+	[TestCase ("FooDir", MSBuildValueKind.Folder)]
+	[TestCase ("FooFile", MSBuildValueKind.File)]
+	[TestCase ("FooFileName", MSBuildValueKind.Filename)]
+	[TestCase ("FooFilename", MSBuildValueKind.Filename)]
+	[TestCase ("FooUrl", MSBuildValueKind.Url)]
+	[TestCase ("FooUri", MSBuildValueKind.Url)]
+	[TestCase ("FooExt", MSBuildValueKind.Extension)]
+	[TestCase ("FooGuid", MSBuildValueKind.Guid)]
+	[TestCase ("FooDirectories", MSBuildValueKind.Folder | MSBuildValueKind.ListSemicolon)]
+	[TestCase ("FooDirs", MSBuildValueKind.Folder | MSBuildValueKind.ListSemicolon)]
+	[TestCase ("FooFiles", MSBuildValueKind.File | MSBuildValueKind.ListSemicolon)]
+	// note: these two are only valid for Property while the rest are valid for Property and Metadata
+	[TestCase ("Configuration", MSBuildValueKind.Configuration)]
+	[TestCase ("Platform", MSBuildValueKind.Platform)]
+	public void TestInferKind (string identifier, MSBuildValueKind kind)
+	{
+		var actual = MSBuildIdentifier.InferValueKind (identifier, MSBuildSyntaxKind.Property);
+		Assert.AreEqual (kind, actual);
+	}
+}

--- a/MonoDevelop.MSBuild.Tests/MSBuildIdentifierTests.cs
+++ b/MonoDevelop.MSBuild.Tests/MSBuildIdentifierTests.cs
@@ -66,6 +66,8 @@ class MSBuildIdentifierTests
 	[TestCase ("RequireFoo", MSBuildValueKind.Bool)]
 	[TestCase ("UseFoo", MSBuildValueKind.Bool)]
 	[TestCase ("AllowFoo", MSBuildValueKind.Bool)]
+	[TestCase ("IsFoo", MSBuildValueKind.Bool)]
+	[TestCase ("HasFoo", MSBuildValueKind.Bool)]
 	[TestCase ("FooEnabled", MSBuildValueKind.Bool)]
 	[TestCase ("FooDisabled", MSBuildValueKind.Bool)]
 	[TestCase ("FooRequired", MSBuildValueKind.Bool)]

--- a/MonoDevelop.MSBuild/Language/Expressions/ExpressionParser.cs
+++ b/MonoDevelop.MSBuild/Language/Expressions/ExpressionParser.cs
@@ -176,7 +176,7 @@ namespace MonoDevelop.MSBuild.Language.Expressions
 
 			ConsumeWhitespace (ref offset);
 
-			string name = ReadMSBuildIdentifier (buffer, ref offset, endOffset);
+			string name = MSBuildIdentifier.TryRead (buffer, ref offset, endOffset);
 			if (name == null) {
 				return new ExpressionError (baseOffset + offset, ExpressionErrorKind.ExpectingItemName, out hasError);
 			}
@@ -347,39 +347,6 @@ namespace MonoDevelop.MSBuild.Language.Expressions
 			return buffer.Substring (start, offset - start);
 
 			static bool IsAsciiLetter (char ch) => (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
-		}
-
-		static string ReadMSBuildIdentifier (string buffer, ref int offset, int endOffset)
-		{
-			if (offset > endOffset) {
-				return null;
-			}
-
-			int start = offset;
-			char ch = buffer [offset];
-			if (!char.IsLetter (ch) && ch != '_') {
-				return null;
-			}
-			offset++;
-
-			char lastChar = ch;
-			while (offset <= endOffset) {
-				ch = buffer [offset];
-				if (!char.IsLetterOrDigit (ch) && ch != '_' && ch != '-') {
-					break;
-				}
-				offset++;
-				lastChar = ch;
-			}
-
-			// Although a dash is a valid char for MSBuild identifiers, we will disallow the last char being a dash
-			// as this will conflict with item transform handling.
-			// We could probably allow this if we special cased it but I really can't see a good reason to do so.
-			if (lastChar == '-') {
-				offset--;
-			}
-
-			return buffer.Substring (start, offset - start);
 		}
 
 		// TODO: improve and unify with the CLR identifier validation in the validator
@@ -720,7 +687,7 @@ namespace MonoDevelop.MSBuild.Language.Expressions
 					return new ExpressionProperty (baseOffset + start, offset - start, propRef);
 				}
 			} else {
-				string name = ReadMSBuildIdentifier (buffer, ref offset, endOffset);
+				string name = MSBuildIdentifier.TryRead (buffer, ref offset, endOffset);
 				if (name == null) {
 					return new ExpressionError (baseOffset + offset, ExpressionErrorKind.ExpectingPropertyName, out hasError);
 				}
@@ -1037,7 +1004,7 @@ namespace MonoDevelop.MSBuild.Language.Expressions
 
 			ConsumeSpace (buffer, ref offset, endOffset);
 
-			string name = ReadMSBuildIdentifier (buffer, ref offset, endOffset);
+			string name = MSBuildIdentifier.TryRead (buffer, ref offset, endOffset);
 			if (name == null) {
 				return new ExpressionError (baseOffset + offset, ExpressionErrorKind.ExpectingMetadataOrItemName, out hasError);
 			}
@@ -1076,7 +1043,7 @@ namespace MonoDevelop.MSBuild.Language.Expressions
 
 			ConsumeSpace (buffer, ref offset, endOffset);
 
-			string metadataName = ReadMSBuildIdentifier (buffer, ref offset, endOffset);
+			string metadataName = MSBuildIdentifier.TryRead (buffer, ref offset, endOffset);
 			if (metadataName == null) {
 				return new IncompleteExpressionError (
 					baseOffset + offset, offset > endOffset, ExpressionErrorKind.ExpectingMetadataName,

--- a/MonoDevelop.MSBuild/Language/MSBuildIdentifier.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildIdentifier.cs
@@ -218,7 +218,9 @@ static class MSBuildIdentifier
 		{ "Disable", MSBuildValueKind.Bool },
 		{ "Require", MSBuildValueKind.Bool },
 		{ "Use", MSBuildValueKind.Bool },
-		{ "Allow", MSBuildValueKind.Bool }
+		{ "Allow", MSBuildValueKind.Bool },
+		{ "Is", MSBuildValueKind.Bool },
+		{ "Has", MSBuildValueKind.Bool }
 	};
 
 	static readonly Dictionary<string, MSBuildValueKind> knownSuffixes = new () {

--- a/MonoDevelop.MSBuild/Language/MSBuildIdentifier.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildIdentifier.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using MonoDevelop.MSBuild.Language.Syntax;
+using MonoDevelop.MSBuild.Language.Typesystem;
+
+namespace MonoDevelop.MSBuild.Language;
+
+static class MSBuildIdentifier
+{
+	/// <summary>
+	/// Tries to read an MSBuild identifier from the <paramref name="buffer"/> between the <paramref name="offset"/> and <paramref name="endOffset"/>,
+	/// and advance the <paramref name="offset"/> to the end of the identifier.
+	/// </summary>
+	public static string? TryRead (string buffer, ref int offset, int endOffset)
+	{
+		if (TryGetLength (buffer, offset, endOffset, out int length)) {
+			string val = buffer.Substring (offset, length);
+			offset += length;
+			return val;
+		}
+		return null;
+	}
+
+	/// <summary>
+	/// Tries to read an MSBuild identifier from the <paramref name="buffer"/> between the <paramref name="offset"/> and <paramref name="endOffset"/>.
+	/// The <paramref name="offset"/> will be advanced to the end of the identifier.
+	/// </summary>
+	/// <param name="buffer"></param>
+	/// <param name="offset"></param>
+	/// <param name="endOffset"></param>
+	/// <returns></returns>
+	public static bool TryGetLength (string buffer, int offset, int endOffset, out int length)
+	{
+		length = 0;
+		if (offset > endOffset) {
+			return false;
+		}
+
+		int start = offset;
+		char ch = buffer[offset];
+		if (!IsIdentifierFirstChar (ch)) {
+			return false;
+		}
+		offset++;
+
+		char lastChar = ch;
+		while (offset <= endOffset) {
+			ch = buffer[offset];
+			if (!IsIdentifierChar (ch)) {
+				break;
+			}
+			offset++;
+			lastChar = ch;
+		}
+
+		// Although a dash is a valid char for MSBuild identifiers, we will disallow the last char being a dash
+		// as this will conflict with item transform handling.
+		// We could probably allow this if we special cased it but I really can't see a good reason to do so.
+		if (lastChar == '-') {
+			offset--;
+		}
+
+		length = offset - start;
+		return true;
+	}
+
+	static bool IsIdentifierChar (char ch) => char.IsLetterOrDigit (ch) || ch == '_' || ch == '-';
+	static bool IsIdentifierFirstChar (char ch) => char.IsLetter (ch) || ch == '_';
+
+	public static bool IsValid (string identifier) => TryGetLength (identifier, 0, identifier.Length - 1, out int length) && length == identifier.Length;
+
+	/// <summary>
+	/// Try to infer the value kind from an identifier.
+	/// </summary>
+	public static MSBuildValueKind InferValueKind (string name, MSBuildSyntaxKind syntaxKind)
+	{
+		if (syntaxKind == MSBuildSyntaxKind.Property || syntaxKind == MSBuildSyntaxKind.Metadata) {
+			if (StartsWith ("Enable")
+				|| StartsWith ("Disable")
+				|| StartsWith ("Require")
+				|| StartsWith ("Use")
+				|| StartsWith ("Allow")
+				|| EndsWith ("Enabled")
+				|| EndsWith ("Disabled")
+				|| EndsWith ("Required")) {
+				return MSBuildValueKind.Bool;
+			}
+			if (EndsWith ("DependsOn")) {
+				return MSBuildValueKind.TargetName.AsList ();
+			}
+			if (EndsWith ("Path")) {
+				return MSBuildValueKind.FileOrFolder;
+			}
+			if (EndsWith ("Paths")) {
+				return MSBuildValueKind.FileOrFolder.AsList ();
+			}
+			if (EndsWith ("Directory")
+				|| EndsWith ("Dir")) {
+				return MSBuildValueKind.Folder;
+			}
+			if (EndsWith ("File")) {
+				return MSBuildValueKind.File;
+			}
+			if (EndsWith ("FileName")) {
+				return MSBuildValueKind.Filename;
+			}
+			if (EndsWith ("Url")) {
+				return MSBuildValueKind.Url;
+			}
+			if (EndsWith ("Ext")) {
+				return MSBuildValueKind.Extension;
+			}
+			if (EndsWith ("Guid")) {
+				return MSBuildValueKind.Guid;
+			}
+			if (EndsWith ("Directories") || EndsWith ("Dirs")) {
+				return MSBuildValueKind.Folder.AsList ();
+			}
+			if (EndsWith ("Files")) {
+				return MSBuildValueKind.File.AsList ();
+			}
+		}
+
+		//make sure these work even if the common targets schema isn't loaded
+		if (syntaxKind == MSBuildSyntaxKind.Property) {
+			if (Equals ("Configuration")) {
+				return MSBuildValueKind.Configuration;
+			}
+			if (Equals ("Platform")) {
+				return MSBuildValueKind.Platform;
+			}
+		}
+
+		return MSBuildValueKind.Unknown;
+
+		bool StartsWith (string prefix) => name.StartsWith (prefix, StringComparison.OrdinalIgnoreCase)
+			&& name.Length > prefix.Length
+			&& char.IsUpper (name[prefix.Length]);
+		bool EndsWith (string suffix) => name.EndsWith (suffix, StringComparison.OrdinalIgnoreCase);
+		bool Equals (string value) => name.Equals (value, StringComparison.OrdinalIgnoreCase);
+	}
+}

--- a/MonoDevelop.MSBuild/Language/MSBuildInferredSchema.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildInferredSchema.cs
@@ -53,6 +53,7 @@ namespace MonoDevelop.MSBuild.Language
 			ItemInfo _ => Items.ContainsKey (info.Name),
 			TaskInfo _ => Tasks.ContainsKey (info.Name),
 			TargetInfo _ => Targets.ContainsKey (info.Name),
+			MetadataInfo m => MetadataUsage.ContainsKey((m.Item?.Name, m.Name)),
 			_ => false
 		};
 

--- a/MonoDevelop.MSBuild/Language/MSBuildInferredSchema.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildInferredSchema.cs
@@ -274,7 +274,7 @@ namespace MonoDevelop.MSBuild.Language
 			MetadataUsage[(itemName, metadataName)] = usage;
 		}
 
-		class InferredMetadataInfo (string name, MSBuildValueKind inferredKind, ItemInfo item) : MetadataInfo (name, null, valueKind: inferredKind, item: item)
+		class InferredMetadataInfo (string name, MSBuildValueKind inferredKind, ItemInfo item) : MetadataInfo (name, null, valueKind: inferredKind, item: item), IInferredSymbol
 		{
 		}
 


### PR DESCRIPTION
Fix some bugs in display of inferred metadata.

Before: 
![image](https://github.com/mhutch/MonoDevelop.MSBuildEditor/assets/183285/2cab76f3-e47c-401d-894f-d1dc7116a168)

After:
![image](https://github.com/mhutch/MonoDevelop.MSBuildEditor/assets/183285/785730fe-555a-4135-bc04-c64c0c033554)
