### PR TITLE
Rework IDeprecatable into IVersionableSymbol

### DIFF
--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/ComAggregate.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/ComAggregate.cs
@@ -33,7 +33,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
 		///          will be forwarded to the managed implementation.
 		/// </summary>
 		internal static object CreateAggregatedObject (object managedObject)
-			=> WrapperPolicy.CreateAggregatedObject (managedObject);
+		{
+			Shell.ThreadHelper.ThrowIfNotOnUIThread ();
+			return WrapperPolicy.CreateAggregatedObject (managedObject);
+		}
 
 		/// <summary>
 		/// Return the RCW for the native IComWrapperFixed instance aggregating "managedObject"

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/ComEventSink.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/ComEventSink.cs
@@ -13,6 +13,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
     {
         public static ComEventSink Advise<T>(object obj, T sink) where T : class
         {
+            Shell.ThreadHelper.ThrowIfNotOnUIThread ();
+
             if (!typeof(T).IsInterface)
             {
                 throw new InvalidOperationException();
@@ -46,6 +48,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         public void Unadvise()
         {
+            Shell.ThreadHelper.ThrowIfNotOnUIThread ();
+
             if (_unadvised)
             {
                 throw new InvalidOperationException("Already unadvised.");

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/WrapperPolicy.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/Interop/WrapperPolicy.cs
@@ -14,12 +14,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
     {
         /// <summary>
         /// Factory object for creating IComWrapperFixed instances.
-        /// Internal and not readonly so that unit tests can provide an alternative implementation.
         /// </summary>
-        internal static IComWrapperFactory s_ComWrapperFactory =
-            (IComWrapperFactory)PackageUtilities.CreateInstance(typeof(IComWrapperFactory).GUID);
+        static IComWrapperFactory? s_ComWrapperFactory;
 
-        internal static object CreateAggregatedObject(object managedObject) => s_ComWrapperFactory.CreateAggregatedObject(managedObject);
+        internal static object CreateAggregatedObject(object managedObject)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            s_ComWrapperFactory ??= (IComWrapperFactory)PackageUtilities.CreateInstance (typeof (IComWrapperFactory).GUID);
+            return s_ComWrapperFactory.CreateAggregatedObject(managedObject);
+        }
 
         /// <summary>
         /// Return the RCW for the native IComWrapperFixed instance aggregating "managedObject"

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
@@ -58,6 +58,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
 			public int RemoveAdornments ()
 			{
+				Shell.ThreadHelper.ThrowIfNotOnUIThread ();
+
 				_sink.Unadvise ();
 
 				return VSConstants.S_OK;

--- a/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.cs
+++ b/MonoDevelop.MSBuild.Editor.VisualStudio/RoslynImport/LanguageService/AbstractLanguageService`2.cs
@@ -60,6 +60,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         /// </summary>
         internal void Setup()
         {
+            Shell.ThreadHelper.ThrowIfNotOnUIThread ();
+
             this.ComAggregate = CreateComAggregate();
 
             // First, acquire any services we need throughout our lifetime.
@@ -84,7 +86,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         }
 
         private object CreateComAggregate()
-            => Interop.ComAggregate.CreateAggregatedObject(this);
+		{
+            Shell.ThreadHelper.ThrowIfNotOnUIThread ();
+            return Interop.ComAggregate.CreateAggregatedObject(this);
+        }
 
         internal void TearDown()
         {

--- a/MonoDevelop.MSBuild.Editor/QuickInfo/MSBuildDiagnosticQuickInfoSource.cs
+++ b/MonoDevelop.MSBuild.Editor/QuickInfo/MSBuildDiagnosticQuickInfoSource.cs
@@ -60,8 +60,10 @@ partial class MSBuildDiagnosticQuickInfoSource : IAsyncQuickInfoSource
 			elements.Add (displayElementFactory.GetDiagnosticTooltip (diagnostic));
 
 			var tagSpan = mappingSpan.Span.GetSpans (snapshot).First ();
-			applicableToSpan = applicableToSpan.HasValue ? applicableToSpan.Value.Overlap (tagSpan) : tagSpan;
+			applicableToSpan = applicableToSpan.HasValue ? (applicableToSpan.Value.Overlap (tagSpan)?? triggerSpan) : tagSpan;
 		}
+
+		applicableToSpan ??= triggerSpan;
 
 		return new QuickInfoItem (
 			snapshot.CreateTrackingSpan (applicableToSpan.Value, SpanTrackingMode.EdgeExclusive),

--- a/MonoDevelop.MSBuild.Editor/Roslyn/RoslynTaskMetadataBuilder.cs
+++ b/MonoDevelop.MSBuild.Editor/Roslyn/RoslynTaskMetadataBuilder.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Logging;
 
 using MonoDevelop.MSBuild.Evaluation;
+using MonoDevelop.MSBuild.Language;
 using MonoDevelop.MSBuild.Language.Expressions;
 using MonoDevelop.MSBuild.Language.Typesystem;
 using MonoDevelop.MSBuild.Schema;
@@ -98,13 +99,15 @@ namespace MonoDevelop.MSBuild.Editor.Roslyn
 			var parameters = new Dictionary<string, TaskParameterInfo> (StringComparer.OrdinalIgnoreCase);
 			GetTaskInfoFromTask (type, logger, parameters, out string? deprecationMessage);
 
+			var versionInfo = deprecationMessage is not null ? SymbolVersionInfo.Deprecated (deprecationMessage) : null;
+
 			return new TaskInfo (
 				type.Name, RoslynHelpers.GetDescription (type),
 				TaskDeclarationKind.Assembly,
 				type.GetFullName (),
 				assemblyName, assemblyFileStr,
 				declaredInFile, declaredAtOffset,
-				deprecationMessage,
+				versionInfo,
 				parameters);
 		}
 
@@ -205,7 +208,9 @@ namespace MonoDevelop.MSBuild.Editor.Roslyn
 				kind = kind.AsList ();
 			}
 
-			return new TaskParameterInfo (prop.Name, RoslynHelpers.GetDescription (prop), isRequired, isOutput, kind, deprecationMessage);
+			var versionInfo = deprecationMessage is not null ? SymbolVersionInfo.Deprecated (deprecationMessage) : null;
+
+			return new TaskParameterInfo (prop.Name, RoslynHelpers.GetDescription (prop), isRequired, isOutput, kind, versionInfo);
 		}
 
 		Dictionary<(string fileExpr, string asmName, string declaredInFile), (string, IAssemblySymbol)?> resolvedAssemblies

--- a/MonoDevelop.MSBuild.Tests.Editor/Completion/MSBuildCommitTests.cs
+++ b/MonoDevelop.MSBuild.Tests.Editor/Completion/MSBuildCommitTests.cs
@@ -24,6 +24,7 @@ namespace MonoDevelop.MSBuild.Tests.Editor.Completion
 				filename: filename,
 				initialize: (tv) => {
 					tv.Options.SetOptionValue ("BraceCompletion/Enabled", true);
+					return Task.CompletedTask;
 				}
 			);
 		}

--- a/MonoDevelop.MSBuild/Language/ISymbol.cs
+++ b/MonoDevelop.MSBuild/Language/ISymbol.cs
@@ -16,14 +16,6 @@ public interface ISymbol
 }
 
 /// <summary>
-/// Common interface for symbols that may be deprecated
-/// </summary>
-public interface IDeprecatable : ISymbol
-{
-	string? DeprecationMessage { get; }
-}
-
-/// <summary>
 /// Common interface for symbols that are typed
 /// </summary>
 public interface ITypedSymbol : ISymbol

--- a/MonoDevelop.MSBuild/Language/IVersionableSymbol.cs
+++ b/MonoDevelop.MSBuild/Language/IVersionableSymbol.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2016 Xamarin Inc.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace MonoDevelop.MSBuild.Language;
+
+/// <summary>
+/// Common interface for symbols that may be deprecated or contain information about when they were introduced
+/// </summary>
+public interface IVersionableSymbol : ISymbol
+{
+	SymbolVersionInfo? VersionInfo { get; }
+}
+
+/// <summary>
+/// Contains information about whether a symbol is deprecated and/or when it was introduced.
+/// </summary>
+/// <param name="DeprecationMessage">If the symbol is deprecated, the deprecation message, otherwise <c>null</c>. Zero-length deprecation messages are not permitted and will be ignored.</param>
+/// <param name="DeprecatedInVersion">Optionally indicate the MSBuild version in which it was deprecated. Ignored if <see cref="DeprecationMessage"/> is <c>null</c>.</param>
+/// <param name="IntroducedInVersion">Optionally indicate the MSBuild version in which the symbol was introduced.</param>
+/// <param name="VersionKind">Indicates what kind of version was provided in <see cref="DeprecatedInVersion"/> and/or <see cref="IntroducedInVersion"/></param>
+public record SymbolVersionInfo (string? DeprecationMessage = null, Version? DeprecatedInVersion = null, Version? IntroducedInVersion = null, SymbolVersionKind VersionKind = SymbolVersionKind.MSBuild)
+{
+	public bool IsDeprecated => !string.IsNullOrEmpty (DeprecationMessage); // TODO: ctor should throw on zero length deprecation messages
+
+	public static SymbolVersionInfo Deprecated(string deprecationMessage) => new (DeprecationMessage: deprecationMessage);
+	public static SymbolVersionInfo Deprecated(int majorVersion, int minorVersion, string deprecationMessage) => new (DeprecationMessage: deprecationMessage, DeprecatedInVersion: new Version (majorVersion, minorVersion));
+
+	public static SymbolVersionInfo Introduced (int majorVersion, int minorVersion) => new (IntroducedInVersion: new Version(majorVersion, minorVersion));
+}
+
+/// <summary>
+/// Indicates what kind of version was provided in the <see cref="SymbolVersionInfo"/>
+/// </summary>
+public enum SymbolVersionKind
+{
+	/// <summary>
+	/// The symbol was deprecated or introduced in a specific version of MSBuild.
+	/// </summary>
+	MSBuild = 0,
+	/// <summary>
+	/// NOT SUPPORTED YET. The symbol was deprecated or introduced in a specific version of the .NET SDK.
+	/// </summary>
+	DotNetSdk,
+	/// <summary>
+	/// NOT SUPPORTED YET. The symbol was deprecated or introduced in a specific version of a NuGet package.
+	/// </summary>
+	NuGetPackage
+}

--- a/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
@@ -63,8 +63,8 @@ namespace MonoDevelop.MSBuild.Language
 		{
 			CheckDeprecated (elementSyntax, element);
 
-			if (elementSymbol != elementSyntax && elementSymbol is IDeprecatable deprecatable) {
-				CheckDeprecated (deprecatable, element);
+			if (elementSymbol != elementSyntax && elementSymbol is IVersionableSymbol versionableSymbol) {
+				CheckDeprecated (versionableSymbol, element);
 			}
 
 			foreach (var rat in elementSyntax.Attributes) {
@@ -165,18 +165,18 @@ namespace MonoDevelop.MSBuild.Language
 			}
 		}
 
-		bool CheckDeprecated (IDeprecatable info, INamedXObject namedObj) => CheckDeprecated (info, namedObj.NameSpan);
+		bool CheckDeprecated (IVersionableSymbol versionableSymbol, INamedXObject namedObj) => CheckDeprecated (versionableSymbol, namedObj.NameSpan);
 
-		bool CheckDeprecated (IDeprecatable info, ExpressionNode expressionNode) => CheckDeprecated (info, expressionNode.Span);
+		bool CheckDeprecated (IVersionableSymbol versionableSymbol, ExpressionNode expressionNode) => CheckDeprecated (versionableSymbol, expressionNode.Span);
 
-		bool CheckDeprecated (IDeprecatable info, TextSpan squiggleSpan)
+		bool CheckDeprecated (IVersionableSymbol versionableSymbol, TextSpan squiggleSpan)
 		{
-			if (info.IsDeprecated (out string? deprecationMessage)) {
+			if (versionableSymbol.IsDeprecated (out string? deprecationMessage)) {
 				Document.Diagnostics.Add (
 					CoreDiagnostics.DeprecatedWithMessage,
 					squiggleSpan,
-					DescriptionFormatter.GetKindNoun (info),
-					info.Name,
+					DescriptionFormatter.GetKindNoun (versionableSymbol),
+					versionableSymbol.Name,
 					deprecationMessage
 				);
 				return true;
@@ -479,8 +479,8 @@ namespace MonoDevelop.MSBuild.Language
 		{
 			CheckDeprecated (attributeSyntax, attribute);
 
-			if (attributeSymbol != attributeSyntax && attributeSymbol is IDeprecatable deprecatable) {
-				CheckDeprecated (deprecatable, attribute);
+			if (attributeSymbol != attributeSyntax && attributeSymbol is IVersionableSymbol versionableSymbol) {
+				CheckDeprecated (versionableSymbol, attribute);
 			}
 
 			if (string.IsNullOrWhiteSpace (attribute.Value)) {
@@ -640,8 +640,8 @@ namespace MonoDevelop.MSBuild.Language
 					AddFixableError (CoreDiagnostics.UnknownValue, DescriptionFormatter.GetTitleCaseKindNoun (valueSymbol), valueSymbol.Name, value);
 					return;
 				}
-				if (isKnownValue && knownValue is IDeprecatable deprecatable) {
-					CheckDeprecated (deprecatable, expressionText);
+				if (isKnownValue && knownValue is IVersionableSymbol versionableSymbol) {
+					CheckDeprecated (versionableSymbol, expressionText);
 				}
 			}
 

--- a/MonoDevelop.MSBuild/Language/MSBuildSymbolExtensions.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildSymbolExtensions.cs
@@ -14,25 +14,24 @@ public static class MSBuildSymbolExtensions
 
 	public static bool HasDescription (this ISymbol symbol) => !symbol.Description.IsEmpty;
 
-	public static bool IsDeprecated (this IDeprecatable symbol) => !string.IsNullOrEmpty (symbol.DeprecationMessage);
+	public static bool IsDeprecated (this IVersionableSymbol symbol) => symbol.VersionInfo?.IsDeprecated ?? false;
 
-	public static bool IsDeprecated (this IDeprecatable symbol, [NotNullWhen (true)] out string? deprecationMessage)
+	public static bool IsDeprecated (this IVersionableSymbol symbol, [NotNullWhen (true)] out string? deprecationMessage)
 	{
-		if (IsDeprecated (symbol)) {
-			deprecationMessage = symbol.DeprecationMessage;
+		if (symbol.VersionInfo is SymbolVersionInfo versionInfo && versionInfo.IsDeprecated) {
+			deprecationMessage = versionInfo.DeprecationMessage;
 			return true;
 		}
 		deprecationMessage = null;
 		return false;
 	}
 
-	public static bool IsDeprecated (this ISymbol symbol) => symbol is IDeprecatable deprecatable && deprecatable.IsDeprecated ();
+	public static bool IsDeprecated (this ISymbol symbol) => symbol is IVersionableSymbol versionableSymbol && versionableSymbol.IsDeprecated ();
 
 	public static bool IsDeprecated (this ISymbol symbol, [NotNullWhen (true)] out string? deprecationMessage)
 	{
-		if (symbol is IDeprecatable deprecatable && deprecatable.IsDeprecated ()) {
-			deprecationMessage = deprecatable.DeprecationMessage;
-			return true;
+		if (symbol is IVersionableSymbol versionableSymbol) {
+			return versionableSymbol.IsDeprecated (out deprecationMessage);
 		}
 		deprecationMessage = null;
 		return false;

--- a/MonoDevelop.MSBuild/Language/Syntax/MSBuildAttributeSyntax.cs
+++ b/MonoDevelop.MSBuild/Language/Syntax/MSBuildAttributeSyntax.cs
@@ -16,9 +16,9 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 			string name, DisplayText description, MSBuildSyntaxKind syntaxKind, MSBuildValueKind valueKind,
 			CustomTypeInfo? customType = null,
 			bool required = false, MSBuildSyntaxKind? abstractKind = null,
-			string? deprecationMessage = null,
+			SymbolVersionInfo? versionInfo = null,
 			string? helpUrl = null)
-			: base (name, description, valueKind, customType, deprecationMessage, helpUrl)
+			: base (name, description, valueKind, customType, versionInfo, helpUrl)
 		{
 			SyntaxKind = syntaxKind;
 			Element = element;

--- a/MonoDevelop.MSBuild/Language/Syntax/MSBuildElementSyntax.cs
+++ b/MonoDevelop.MSBuild/Language/Syntax/MSBuildElementSyntax.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 
 using MonoDevelop.MSBuild.Language.Typesystem;
+using MonoDevelop.MSBuild.Schema;
 using MonoDevelop.Xml.Dom;
 
 namespace MonoDevelop.MSBuild.Language.Syntax
@@ -34,8 +35,8 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 			string name, DisplayText description, MSBuildSyntaxKind syntaxKind,
 			MSBuildValueKind valueKind = MSBuildValueKind.Nothing,
 			CustomTypeInfo? customType = null,
-			bool isAbstract = false, string deprecationMessage = null, string helpUrl = null, string attributesHelpUrl = null)
-			: base (name, description, valueKind, customType, deprecationMessage, helpUrl)
+			bool isAbstract = false, SymbolVersionInfo? versionInfo = null, string helpUrl = null, string? attributesHelpUrl = null)
+			: base (name, description, valueKind, customType, versionInfo, helpUrl)
 		{
 			SyntaxKind = syntaxKind;
 			IsAbstract = isAbstract;
@@ -275,7 +276,7 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 				new (Project, "InitialTargets", ElementDescriptions.Project_InitialTargets, MSBuildSyntaxKind.Project_InitialTargets, MSBuildValueKind.TargetName.AsList ().AsLiteral (),
 					helpUrl: "https://learn.microsoft.com/en-us/visualstudio/msbuild/target-build-order#initial-targets"
 				),
-				new (Project, "ToolsVersion", ElementDescriptions.Project_ToolsVersion, MSBuildSyntaxKind.Project_ToolsVersion, MSBuildValueKind.ToolsVersion.AsLiteral (), deprecationMessage: "Ignored in modern MSBuild projects"),
+				new (Project, "ToolsVersion", ElementDescriptions.Project_ToolsVersion, MSBuildSyntaxKind.Project_ToolsVersion, MSBuildValueKind.ToolsVersion.AsLiteral (), versionInfo: MSBuildIntrinsics.ToolsVersionDeprecatedInfo, helpUrl: HelpUrls.Element_Project_ToolsVersion),
 				new (Project, "TreatAsLocalProperty", ElementDescriptions.Project_TreatAsLocalProperty, MSBuildSyntaxKind.Project_TreatAsLocalProperty, MSBuildValueKind.PropertyName.AsList ().AsLiteral ()),
 				new (Project, "xmlns", ElementDescriptions.Project_xmlns, MSBuildSyntaxKind.Project_xmlns, MSBuildValueKind.Xmlns.AsLiteral ()),
 				new (Project, "Sdk", ElementDescriptions.Project_Sdk, MSBuildSyntaxKind.Project_Sdk, MSBuildValueKind.SdkWithVersion.AsList().AsLiteral ()),

--- a/MonoDevelop.MSBuild/Language/Syntax/MSBuildSyntax.cs
+++ b/MonoDevelop.MSBuild/Language/Syntax/MSBuildSyntax.cs
@@ -4,21 +4,23 @@
 
 #nullable enable
 
+using System;
+
 using MonoDevelop.MSBuild.Language.Typesystem;
 
 namespace MonoDevelop.MSBuild.Language.Syntax;
 
-public abstract class MSBuildSyntax : ISymbol, ITypedSymbol, IDeprecatable, IHasHelpUrl
+public abstract class MSBuildSyntax : ISymbol, ITypedSymbol, IVersionableSymbol, IHasHelpUrl
 {
 	protected MSBuildSyntax (
 		string name, DisplayText description, MSBuildValueKind valueKind = MSBuildValueKind.Unknown,
 		CustomTypeInfo? customType = null,
-		string? deprecationMessage = null,
+		SymbolVersionInfo? versionInfo = null,
 		string? helpUrl = null)
 	{
 		Name = name;
 		Description = description;
-		DeprecationMessage = deprecationMessage;
+		VersionInfo = versionInfo;
 		HelpUrl = helpUrl;
 
 		ValueKind = valueKind;
@@ -30,6 +32,6 @@ public abstract class MSBuildSyntax : ISymbol, ITypedSymbol, IDeprecatable, IHas
 
 	public virtual MSBuildValueKind ValueKind { get; }
 	public CustomTypeInfo? CustomType { get; }
-	public string? DeprecationMessage { get; }
+	public SymbolVersionInfo? VersionInfo { get; }
 	public virtual string? HelpUrl { get; }
 }

--- a/MonoDevelop.MSBuild/Language/Typesystem/ConstantSymbol.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/ConstantSymbol.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+
 namespace MonoDevelop.MSBuild.Language.Typesystem
 {
 	/// <summary>
 	/// Describes a constant's name and type (but not its value)
 	/// </summary>
+	[DebuggerDisplay("ConstantSymbol({Name},nq)")]
 	public class ConstantSymbol : BaseSymbol, ITypedSymbol
 	{
 		public ConstantSymbol (string name, DisplayText description, MSBuildValueKind kind) : base (name, description)

--- a/MonoDevelop.MSBuild/Language/Typesystem/CustomTypeInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/CustomTypeInfo.cs
@@ -5,9 +5,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace MonoDevelop.MSBuild.Language.Typesystem
 {
+	[DebuggerDisplay("CustomTypeInfo({Name},nq)")]
 	public sealed class CustomTypeInfo
 	{
 		public CustomTypeInfo (

--- a/MonoDevelop.MSBuild/Language/Typesystem/CustomTypeValue.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/CustomTypeValue.cs
@@ -2,11 +2,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace MonoDevelop.MSBuild.Language.Typesystem;
 
+[DebuggerDisplay("CustomTypeValue({Name},nq)")]
 public sealed class CustomTypeValue (
 	string name, DisplayText description, SymbolVersionInfo? versionInfo = null, string? helpUrl = null,
 	IReadOnlyList<string>? aliases = null)

--- a/MonoDevelop.MSBuild/Language/Typesystem/CustomTypeValue.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/CustomTypeValue.cs
@@ -2,12 +2,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace MonoDevelop.MSBuild.Language.Typesystem;
 
-public sealed class CustomTypeValue (string name, DisplayText description, string? deprecationMessage = null, string? helpUrl = null, IReadOnlyList<string>? aliases = null)
-	: ISymbol, ITypedSymbol, IDeprecatable, IHasHelpUrl
+public sealed class CustomTypeValue (
+	string name, DisplayText description, SymbolVersionInfo? versionInfo = null, string? helpUrl = null,
+	IReadOnlyList<string>? aliases = null)
+	: ISymbol, ITypedSymbol, IVersionableSymbol, IHasHelpUrl
 {
 	public CustomTypeInfo CustomType { get; private set; }
 
@@ -17,7 +20,7 @@ public sealed class CustomTypeValue (string name, DisplayText description, strin
 
 	public DisplayText Description { get; } = description;
 
-	public string? DeprecationMessage { get; } = deprecationMessage;
+	public SymbolVersionInfo? VersionInfo { get; } = versionInfo;
 
 	public string? HelpUrl => helpUrl ?? CustomType?.HelpUrl;
 

--- a/MonoDevelop.MSBuild/Language/Typesystem/FrameworkInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/FrameworkInfo.cs
@@ -11,17 +11,19 @@ namespace MonoDevelop.MSBuild.Language.Typesystem
 	// a shortname, identifier, version or profile
 	// the "name" is the piece that's being represented and the reference is the
 	// full ID, or as close to it as we have
-	class FrameworkInfo : BaseSymbol, IDeprecatable
+	class FrameworkInfo : BaseSymbol, IVersionableSymbol
 	{
 		public FrameworkInfo (string name, NuGetFramework reference, string? deprecationMessage = null)
 			: base (name, null)
 		{
 			Reference = reference;
-			DeprecationMessage = deprecationMessage;
+			if (deprecationMessage is not null) {
+				VersionInfo = SymbolVersionInfo.Deprecated (deprecationMessage);
+			}
 		}
 
 		public NuGetFramework Reference { get; }
 
-		public string? DeprecationMessage { get; }
+		public SymbolVersionInfo? VersionInfo { get; }
 	}
 }

--- a/MonoDevelop.MSBuild/Language/Typesystem/ItemInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/ItemInfo.cs
@@ -12,9 +12,9 @@ public class ItemInfo (
 	string name, DisplayText description, string? includeDescription = null,
 	MSBuildValueKind valueKind = MSBuildValueKind.Unknown, CustomTypeInfo? customType = null,
 	Dictionary<string, MetadataInfo>? metadata = null,
-	string? deprecationMessage = null,
+	SymbolVersionInfo? versionInfo = null,
 	string? helpUrl = null)
-	: VariableInfo(name, description, valueKind, customType, null, deprecationMessage), IHasHelpUrl
+	: VariableInfo(name, description, valueKind, customType, null, versionInfo), IHasHelpUrl
 {
 	public Dictionary<string, MetadataInfo> Metadata { get; } = metadata ?? new (System.StringComparer.OrdinalIgnoreCase);
 

--- a/MonoDevelop.MSBuild/Language/Typesystem/ItemInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/ItemInfo.cs
@@ -5,9 +5,11 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace MonoDevelop.MSBuild.Language.Typesystem;
 
+[DebuggerDisplay("ItemInfo({Name},nq)")]
 public class ItemInfo (
 	string name, DisplayText description, string? includeDescription = null,
 	MSBuildValueKind valueKind = MSBuildValueKind.Unknown, CustomTypeInfo? customType = null,

--- a/MonoDevelop.MSBuild/Language/Typesystem/MetadataInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/MetadataInfo.cs
@@ -2,10 +2,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+
 namespace MonoDevelop.MSBuild.Language.Typesystem;
 
+[DebuggerDisplay("MetadataInfo({DebuggerName},nq)")]
 public class MetadataInfo : VariableInfo, IHasHelpUrl
 {
+	[DebuggerHidden]
+	string DebuggerName => Item?.Name is string itemName? $"{itemName}.{Name}" : null;
+
 	public bool Reserved { get; }
 	public bool Required { get; }
 

--- a/MonoDevelop.MSBuild/Language/Typesystem/MetadataInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/MetadataInfo.cs
@@ -14,9 +14,9 @@ public class MetadataInfo : VariableInfo, IHasHelpUrl
 		bool reserved = false, bool required = false, MSBuildValueKind valueKind = MSBuildValueKind.Unknown,
 		ItemInfo? item = null, CustomTypeInfo? customType = null,
 		string? defaultValue = null,
-		string? deprecationMessage = null,
+		SymbolVersionInfo? versionInfo = null,
 		string? helpUrl = null)
-		: base (name, description, valueKind, customType, defaultValue, deprecationMessage)
+		: base (name, description, valueKind, customType, defaultValue, versionInfo)
 	{
 		Item = item;
 		Required = required;

--- a/MonoDevelop.MSBuild/Language/Typesystem/PropertyInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/PropertyInfo.cs
@@ -2,8 +2,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+
 namespace MonoDevelop.MSBuild.Language.Typesystem
 {
+	[DebuggerDisplay("PropertyInfo({Name},nq)")]
 	public class PropertyInfo : VariableInfo, IHasHelpUrl
 	{
 		public bool IsReserved { get; }

--- a/MonoDevelop.MSBuild/Language/Typesystem/PropertyInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/PropertyInfo.cs
@@ -15,9 +15,9 @@ namespace MonoDevelop.MSBuild.Language.Typesystem
 			string name, DisplayText description,
 			MSBuildValueKind valueKind = MSBuildValueKind.Unknown,
 			CustomTypeInfo? customType = null, string? defaultValue = null,
-			string? deprecationMessage = null,
+			SymbolVersionInfo? versionInfo = null,
 			string? helpUrl = null)
-			: base (name, description, valueKind, customType, defaultValue, deprecationMessage)
+			: base (name, description, valueKind, customType, defaultValue, versionInfo)
 		{
 			HelpUrl = helpUrl;
 		}
@@ -27,9 +27,9 @@ namespace MonoDevelop.MSBuild.Language.Typesystem
 			bool isReserved, bool isReadOnly,
 			MSBuildValueKind valueKind = MSBuildValueKind.Unknown,
 			CustomTypeInfo? customType = null, string? defaultValue = null,
-			string? deprecationMessage = null,
+			SymbolVersionInfo? versionInfo = null,
 			string? helpUrl = null)
-			: base (name, description, valueKind, customType, defaultValue, deprecationMessage)
+			: base (name, description, valueKind, customType, defaultValue, versionInfo)
 		{
 			IsReserved = isReserved;
 			IsReadOnly = isReadOnly;

--- a/MonoDevelop.MSBuild/Language/Typesystem/TargetInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/TargetInfo.cs
@@ -3,9 +3,11 @@
 
 namespace MonoDevelop.MSBuild.Language.Typesystem;
 
-public class TargetInfo (string name, DisplayText description, string? deprecationMessage = null, string? helpUrl = null)
-	: BaseSymbol(name, description), IDeprecatable, IHasHelpUrl
+public class TargetInfo (
+	string name, DisplayText description, SymbolVersionInfo? versionInfo = null, string? helpUrl = null
+	)
+	: BaseSymbol(name, description), IVersionableSymbol, IHasHelpUrl
 {
-	public string? DeprecationMessage { get; } = deprecationMessage;
+	public SymbolVersionInfo? VersionInfo { get; } = versionInfo;
 	public string? HelpUrl { get; } = helpUrl;
 }

--- a/MonoDevelop.MSBuild/Language/Typesystem/TargetInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/TargetInfo.cs
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+
 namespace MonoDevelop.MSBuild.Language.Typesystem;
 
+[DebuggerDisplay("TargetInfo({Name},nq)")]
 public class TargetInfo (
 	string name, DisplayText description, SymbolVersionInfo? versionInfo = null, string? helpUrl = null
 	)

--- a/MonoDevelop.MSBuild/Language/Typesystem/TaskInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/TaskInfo.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace MonoDevelop.MSBuild.Language.Typesystem
 {
-	public class TaskInfo : BaseSymbol, IDeprecatable, ITypedSymbol, IHasHelpUrl
+	public class TaskInfo : BaseSymbol, IVersionableSymbol, ITypedSymbol, IHasHelpUrl
 	{
 		Dictionary<string, TaskParameterInfo> parameters;
 
@@ -29,7 +29,7 @@ namespace MonoDevelop.MSBuild.Language.Typesystem
 		/// All other kinds of task
 		/// </summary>
 		public TaskInfo (string name, DisplayText description, TaskDeclarationKind declarationKind, string? typeName, string? assemblyName, string? assemblyFile, string? declaredInFile, int declaredAtOffset,
-			string? deprecationMessage, Dictionary<string, TaskParameterInfo>? parameters = null, string? helpUrl = null, string? parametersHelpUrl = null
+			SymbolVersionInfo? versionInfo, Dictionary<string, TaskParameterInfo>? parameters = null, string? helpUrl = null, string? parametersHelpUrl = null
 			)
 			: base (name, description)
 		{
@@ -39,7 +39,7 @@ namespace MonoDevelop.MSBuild.Language.Typesystem
 			AssemblyFile = assemblyFile;
 			DeclaredInFile = declaredInFile;
 			DeclaredAtOffset = declaredAtOffset;
-			DeprecationMessage = deprecationMessage;
+			VersionInfo = versionInfo;
 			this.parameters = parameters ?? new Dictionary<string, TaskParameterInfo> (StringComparer.OrdinalIgnoreCase);
 			HelpUrl = helpUrl;
 			ParametersHelpUrl = parametersHelpUrl;
@@ -67,7 +67,7 @@ namespace MonoDevelop.MSBuild.Language.Typesystem
 		public string? DeclaredInFile { get; }
 		public int DeclaredAtOffset { get; }
 
-		public string? DeprecationMessage { get; }
+		public SymbolVersionInfo? VersionInfo { get; }
 
 		public MSBuildValueKind ValueKind => MSBuildValueKind.Nothing;
 
@@ -133,8 +133,8 @@ namespace MonoDevelop.MSBuild.Language.Typesystem
 
 		public TaskParameterInfo (
 			string name, DisplayText description, bool isRequired,
-			bool isOutput, MSBuildValueKind kind, string deprecationMessage = null, string? helpUrl = null)
-			: base (name, description, kind, null, null, deprecationMessage)
+			bool isOutput, MSBuildValueKind kind, SymbolVersionInfo? versionInfo = null, string? helpUrl = null)
+			: base (name, description, kind, null, null, versionInfo)
 		{
 			IsOutput = isOutput;
 			IsRequired = isRequired;

--- a/MonoDevelop.MSBuild/Language/Typesystem/TaskInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/TaskInfo.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace MonoDevelop.MSBuild.Language.Typesystem
 {
+	[DebuggerDisplay("TaskInfo({Name},nq)")]
 	public class TaskInfo : BaseSymbol, IVersionableSymbol, ITypedSymbol, IHasHelpUrl
 	{
 		Dictionary<string, TaskParameterInfo> parameters;

--- a/MonoDevelop.MSBuild/Language/Typesystem/VariableInfo.cs
+++ b/MonoDevelop.MSBuild/Language/Typesystem/VariableInfo.cs
@@ -6,11 +6,11 @@ using System;
 
 namespace MonoDevelop.MSBuild.Language.Typesystem;
 
-public abstract class VariableInfo : BaseSymbol, ITypedSymbol, IDeprecatable
+public abstract class VariableInfo : BaseSymbol, ITypedSymbol, IVersionableSymbol
 {
 	protected VariableInfo (
 		string name, DisplayText description, MSBuildValueKind valueKind = MSBuildValueKind.Unknown,
-		CustomTypeInfo? customType = null, string? defaultValue = null, string? deprecationMessage = null)
+		CustomTypeInfo? customType = null, string? defaultValue = null, SymbolVersionInfo? versionInfo = null)
 		: base (name, description)
 	{
 		if (valueKind.IsCustomType () && customType == null) {
@@ -24,12 +24,12 @@ public abstract class VariableInfo : BaseSymbol, ITypedSymbol, IDeprecatable
 
 		CustomType = customType;
 		DefaultValue = defaultValue;
-		DeprecationMessage = deprecationMessage;
+		VersionInfo = versionInfo;
 		ValueKind = valueKind;
 	}
 
 	public MSBuildValueKind ValueKind { get; }
 	public CustomTypeInfo? CustomType { get; }
 	public string? DefaultValue { get; }
-	public string? DeprecationMessage { get; }
+	public SymbolVersionInfo? VersionInfo { get; }
 }

--- a/MonoDevelop.MSBuild/Resources/HelpDescriptions.resx
+++ b/MonoDevelop.MSBuild/Resources/HelpDescriptions.resx
@@ -345,4 +345,7 @@
   <data name="ReservedProperty_MSBuildSemanticVersion" xml:space="preserve">
     <value>The full version of the MSBuild assemblies in use in SemVer format.</value>
   </data>
+  <data name="ToolsVersion_Deprecated" xml:space="preserve">
+    <value>The `ToolsVersion` property is ignored in MSBuild 16.0 and later.</value>
+  </data>
 </root>

--- a/MonoDevelop.MSBuild/Resources/HelpUrls.resx
+++ b/MonoDevelop.MSBuild/Resources/HelpUrls.resx
@@ -199,6 +199,9 @@
   <data name="Element_Project_Attributes" xml:space="preserve">
     <value>https://learn.microsoft.com/visualstudio/msbuild/project-element-msbuild#attributes</value>
   </data>
+  <data name="Element_Project_ToolsVersion" xml:space="preserve">
+    <value>https://learn.microsoft.com/visualstudio/msbuild/msbuild-toolset-toolsversion</value>
+  </data>
   <data name="Element_Property" xml:space="preserve">
     <value>https://learn.microsoft.com/visualstudio/msbuild/property-element-msbuild</value>
   </data>

--- a/MonoDevelop.MSBuild/Schema/MSBuildIntrinsics.cs
+++ b/MonoDevelop.MSBuild/Schema/MSBuildIntrinsics.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 
+using MonoDevelop.MSBuild.Language;
 using MonoDevelop.MSBuild.Language.Typesystem;
 
 using ReservedPropertyNames = Microsoft.Build.Internal.ReservedPropertyNames;
@@ -22,11 +23,17 @@ namespace MonoDevelop.MSBuild.Schema
 			Metadata.Add (name, new MetadataInfo (name, description, !notReserved, false, kind, helpUrl: HelpUrls.WellKnownMetadata));
 		}
 
-		static void AddReservedProperty (string name, string description, MSBuildValueKind kind, string helpUrl = null) => Properties.Add (name, new PropertyInfo (name, description, true, true, kind, helpUrl: helpUrl));
-		static void AddReadOnlyProperty (string name, string description, MSBuildValueKind kind, string helpUrl = null) => Properties.Add (name, new PropertyInfo (name, description, false, true, kind, helpUrl: helpUrl));
-		static void AddSettableProperty (string name, string description, MSBuildValueKind kind = MSBuildValueKind.Unknown, string helpUrl = null) => Properties.Add (name, new PropertyInfo (name, description, false, false, kind, helpUrl: helpUrl));
+		static void AddReservedProperty (string name, string description, MSBuildValueKind kind, SymbolVersionInfo? versionInfo = null, string? helpUrl = null)
+			=> Properties.Add (name, new PropertyInfo (name, description, true, true, kind, versionInfo: versionInfo, helpUrl: helpUrl));
+
+		static void AddReadOnlyProperty (string name, string description, MSBuildValueKind kind, SymbolVersionInfo? versionInfo = null, string? helpUrl = null)
+				=> Properties.Add (name, new PropertyInfo (name, description, false, true, kind, versionInfo: versionInfo, helpUrl: helpUrl));
+		static void AddSettableProperty (string name, string description, MSBuildValueKind kind = MSBuildValueKind.Unknown, SymbolVersionInfo? versionInfo = null, string? helpUrl = null)
+			=> Properties.Add (name, new PropertyInfo (name, description, false, false, kind, versionInfo: versionInfo, helpUrl: helpUrl));
 
 		static void AddTask (TaskInfo task) => Tasks.Add (task.Name, task);
+
+		static internal SymbolVersionInfo ToolsVersionDeprecatedInfo => SymbolVersionInfo.Deprecated (16, 0, HelpDescriptions.ToolsVersion_Deprecated);
 
 		static MSBuildIntrinsics ()
 		{
@@ -46,16 +53,18 @@ namespace MonoDevelop.MSBuild.Schema
 			AddMetadata ("DefiningProjectName", HelpDescriptions.WellKnownMetadata_DefiningProjectName, MSBuildValueKind.Filename);
 			AddMetadata ("DefiningProjectExtension", HelpDescriptions.WellKnownMetadata_DefiningProjectExtension, MSBuildValueKind.Extension);
 
+			var introducedIn17_0 = SymbolVersionInfo.Introduced (17, 0);
+
 			// TODO: should we move these to a special-cased schema file?
 			// NOTE: the HelpUrl has only been added to properties that as on 4/5/2024 are known to be
 			// in https://learn.microsoft.com/visualstudio/msbuild/msbuild-reserved-and-well-known-properties
 			// or https://learn.microsoft.com/visualstudio/msbuild/common-msbuild-project-properties
 			AddReservedProperty (ReservedPropertyNames.binPath, HelpDescriptions.ReservedProperty_BinPath, MSBuildValueKind.Folder, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
 			AddReservedProperty (ReservedPropertyNames.toolsPath, HelpDescriptions.ReservedProperty_ToolsPath, MSBuildValueKind.Folder, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
-			AddReservedProperty (ReservedPropertyNames.toolsVersion, HelpDescriptions.ReservedProperty_ToolsVersion, MSBuildValueKind.ToolsVersion, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
+			AddReservedProperty (ReservedPropertyNames.toolsVersion, HelpDescriptions.ReservedProperty_ToolsVersion, MSBuildValueKind.ToolsVersion, ToolsVersionDeprecatedInfo, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
 			AddReservedProperty (ReservedPropertyNames.assemblyVersion, HelpDescriptions.ReservedProperty_AssemblyVersion, MSBuildValueKind.Version, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
-			AddReservedProperty (ReservedPropertyNames.fileVersion, HelpDescriptions.ReservedProperty_MSBuildFileVersion, MSBuildValueKind.Version, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
-			AddReservedProperty (ReservedPropertyNames.semanticVersion, HelpDescriptions.ReservedProperty_MSBuildSemanticVersion, MSBuildValueKind.VersionSuffixed, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
+			AddReservedProperty (ReservedPropertyNames.fileVersion, HelpDescriptions.ReservedProperty_MSBuildFileVersion, MSBuildValueKind.Version, introducedIn17_0, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
+			AddReservedProperty (ReservedPropertyNames.semanticVersion, HelpDescriptions.ReservedProperty_MSBuildSemanticVersion, MSBuildValueKind.VersionSuffixed, introducedIn17_0, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
 			AddReservedProperty (ReservedPropertyNames.startupDirectory, HelpDescriptions.ReservedProperty_StartupDirectory, MSBuildValueKind.Folder, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
 			AddReservedProperty (ReservedPropertyNames.buildNodeCount, HelpDescriptions.ReservedProperty_BuildNodeCount, MSBuildValueKind.Int, helpUrl: HelpUrls.ReservedAndWellKnownProperties);
 			AddReservedProperty (ReservedPropertyNames.lastTaskResult, HelpDescriptions.ReservedProperty_LastTaskResult, MSBuildValueKind.Bool, helpUrl: HelpUrls.ReservedAndWellKnownProperties);

--- a/MonoDevelop.MSBuild/Schema/MSBuildSchema.cs
+++ b/MonoDevelop.MSBuild/Schema/MSBuildSchema.cs
@@ -12,11 +12,18 @@ using MonoDevelop.MSBuild.Language.Typesystem;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Diagnostics;
 
 namespace MonoDevelop.MSBuild.Schema
 {
+	[DebuggerDisplay("MSBuildSchema({OriginShort,nq})")]
 	partial class MSBuildSchema : IMSBuildSchema, IEnumerable<ISymbol>, IEnumerable<CustomTypeInfo>
 	{
+		string origin;
+
+		[DebuggerHidden]
+		string OriginShort => Path.GetFileName(origin);
+
 		public Dictionary<string, PropertyInfo> Properties { get; } = new Dictionary<string, PropertyInfo> (StringComparer.OrdinalIgnoreCase);
 		public Dictionary<string, ItemInfo> Items { get; } = new Dictionary<string, ItemInfo> (StringComparer.OrdinalIgnoreCase);
 		public Dictionary<string, TaskInfo> Tasks { get; } = new Dictionary<string, TaskInfo> (StringComparer.OrdinalIgnoreCase);
@@ -66,6 +73,7 @@ namespace MonoDevelop.MSBuild.Schema
 		void LoadInternal (TextReader reader, out IList<MSBuildSchemaLoadError> loadErrors, string origin)
 		{
 			var state = new SchemaLoadState (origin);
+			this.origin = origin;
 
 			JObject doc;
 			using (var jr = new JsonTextReader (reader)) {

--- a/MonoDevelop.MSBuild/Schemas/buildschema.json
+++ b/MonoDevelop.MSBuild/Schemas/buildschema.json
@@ -73,6 +73,7 @@
               "default": false
             },
             "deprecationMessage": { "$ref": "#/definitions/deprecationMessage" },
+            "versionInfo": { "$ref": "#/definitions/versionInfo" },
             "helpUrl": { "$ref": "#/definitions/helpUrl" }
           },
           "additionalProperties": false
@@ -114,6 +115,7 @@
               "default": false
             },
             "deprecationMessage": { "$ref": "#/definitions/deprecationMessage" },
+            "versionInfo": { "$ref": "#/definitions/versionInfo" },
             "helpUrl": { "$ref": "#/definitions/helpUrl" }
           },
           "additionalProperties": false
@@ -144,6 +146,7 @@
               "type": "boolean"
             },
             "deprecationMessage": { "$ref": "#/definitions/deprecationMessage" },
+            "versionInfo": { "$ref": "#/definitions/versionInfo" },
             "helpUrl": { "$ref": "#/definitions/helpUrl" }
           },
           "additionalProperties": false
@@ -164,6 +167,7 @@
               "description": "Description of the target"
             },
             "deprecationMessage": { "$ref": "#/definitions/deprecationMessage" },
+            "versionInfo": { "$ref": "#/definitions/versionInfo" },
             "helpUrl": { "$ref": "#/definitions/helpUrl" }
           },
           "additionalProperties": false
@@ -265,6 +269,7 @@
                     "description": "Description of the value"
                   },
                   "deprecationMessage": { "$ref": "#/definitions/deprecationMessage" },
+                  "versionInfo": { "$ref": "#/definitions/versionInfo" },
                   "helpUrl": { "$ref": "#/definitions/helpUrl" },
                   "aliases": {
                     "type": "array",
@@ -474,11 +479,48 @@
       "description": "Indicates that the symbol is deprecated and explains why.",
       "minLength": 1
     },
+    "versionInfo": {
+      "type": "object",
+      "properties": {
+        "kind": { "$ref": "#/definitions/versionKind" },
+        "introduced": {
+          "type": "string",
+          "description": "The version in which this symbol was introduced. Depending on the value of `versionKind`, this version may refer to MSBuild, the .NET SDK, or a NuGet package."
+        },
+        "deprecated": {
+          "type": "string",
+          "description": "The version in which this symbol was deprecated. Only valid when `deprecationMessage` is set. Depending on the value of `versionKind`, this version may refer to MSBuild, the .NET SDK, or a NuGet package."
+        },
+        "ignored": {
+          "type": "boolean",
+          "description": "If the symbol is deprecated, indicates that it is ignored and assignments may be removed safely."
+        }
+      },
+      "additionalProperties": false
+    },
     "helpUrl": {
       "type": "string",
       "description": "Documentation link to be displayed in UI.",
       "minLength": 1,
       "format": "uri"
+    },
+    "versionKind": {
+      "description": "Explicitly specify what the `since` and `deprecated` versions refer to. A default value is inferred e.g. schemas in the .NET SDK directory default to `DotNetSdk`, and schemas in the MSBuild `bin` directory or bundled with editor default to `MSBuild`.",
+      "type": "string",
+      "anyOf": [
+        {
+          "const": "MSBuild",
+          "description": "The symbol was deprecated or introduced in a specific version of MSBuild"
+        },
+        {
+          "const": "DotNetSdk",
+          "description": "The symbol was deprecated or introduced in a specific version of the .NET SDK"
+        },
+        {
+          "const": "NuGetPackage",
+          "description": "The symbol was deprecated or introduced in a specific version of a NuGet package"
+        }
+      ]
     }
   }
 }

--- a/MonoDevelop.MSBuild/Util/MSBuildLoggerExtensions.cs
+++ b/MonoDevelop.MSBuild/Util/MSBuildLoggerExtensions.cs
@@ -16,9 +16,9 @@ static partial class MSBuildLoggerExtensions
 	/// Helper for switch expressions to log a message about missing cases when they can gracefully return a default value instead of throwing
 	/// </summary>
 	/// <remarks>This must be kept internal so that analyzers and fixes don't use it, as it does not sanitize the callsite for PII.</remarks>
-	internal static TReturn LogUnhandledCaseAndReturnDefaultValue<TReturn,TSwitchValue> (this ILogger logger, TReturn valueToReturn, TSwitchValue missingValue, [CallerMemberName] string methodName = null, [CallerFilePath] string filePath = null, [CallerLineNumber] int lineNumber = 0)
+	internal static TReturn LogUnhandledCaseAndReturnDefaultValue<TReturn,TSwitchValue> (this ILogger logger, TReturn valueToReturn, TSwitchValue missingValue, [CallerMemberName] string? methodName = null, [CallerFilePath] string? filePath = null, [CallerLineNumber] int lineNumber = 0) where TSwitchValue : notnull
 	{
-		LogUnhandledCase(logger, missingValue, methodName, filePath, lineNumber);
+		LogUnhandledCase(logger, missingValue, methodName!, filePath!, lineNumber);
 		return valueToReturn;
 	}
 

--- a/XsdSchemaImporter/MSBuildSchemaUtils.cs
+++ b/XsdSchemaImporter/MSBuildSchemaUtils.cs
@@ -78,7 +78,7 @@ static class MSBuildSchemaUtils
 		foreach (var op in otherSchema.Properties.Values) {
 			var otherProp = op;
 			if (treatStringValueKindAsUnknownInOther && otherProp.ValueKind == MSBuildValueKind.String) {
-				otherProp = new PropertyInfo (otherProp.Name, otherProp.Description, otherProp.IsReserved, otherProp.IsReadOnly, MSBuildValueKind.Unknown, null, otherProp.DefaultValue, otherProp.DeprecationMessage);
+				otherProp = new PropertyInfo (otherProp.Name, otherProp.Description, otherProp.IsReserved, otherProp.IsReadOnly, MSBuildValueKind.Unknown, null, otherProp.DefaultValue, otherProp.VersionInfo);
 			}
 			if (!basisSchema.Properties.TryGetValue(otherProp.Name, out var basisProp)) {
 				if (!otherProp.Description.IsEmpty || otherProp.ValueKind != MSBuildValueKind.Unknown) {
@@ -125,7 +125,7 @@ static class MSBuildSchemaUtils
 	}
 
 	static void AddRange<TValue>(string valueKind, Dictionary<string, TValue> d, IEnumerable<KeyValuePair<string, TValue>> range)
-		where TValue : BaseSymbol, MonoDevelop.MSBuild.Language.IDeprecatable
+		where TValue : BaseSymbol, IVersionableSymbol
 	{
 		foreach (var kv in range) {
 			if (!d.TryAdd(kv.Key, kv.Value)) {


### PR DESCRIPTION
Replace the `IDeprecatable` symbol interface with a new `IVersionableSymbol` interface, which allows symbols to contain information about the version in which the symbol was deprecated or introduced. We don't do anything with this info yet but having this mechanism means we can now start annotating symbols with this info in preparation for future use.

This info is stored on a `SymbolVersionInfo` object so it's easier to expand in future without touching every implementation of
the interface. This also means that the increased memory cost is paid only by the small number of versionable symbols that contain version info.