### PR TITLE
Allow negative literals in conditions

### DIFF
--- a/MonoDevelop.MSBuild.Tests/MSBuildConditionTests.cs
+++ b/MonoDevelop.MSBuild.Tests/MSBuildConditionTests.cs
@@ -131,6 +131,8 @@ namespace MonoDevelop.MSBuild.Tests
 		[TestCase ("'$(foo)' == '' and ('$(bar)' == '')")] // paren group at end of expression string
 		[TestCase ("")] // empty expression
 		[TestCase (" ")] // whitespace only
+		[TestCase ("'$(foo)' > 1.0")] // decimal literal
+		[TestCase ("'$(foo)' > -1.0")] // negative decimal literal
 		public void TestParseNoError (string expressionString)
 		{
 			var expression = ExpressionParser.ParseCondition (expressionString, 0);

--- a/MonoDevelop.MSBuild/Language/Expressions/ExpressionParser.Conditions.cs
+++ b/MonoDevelop.MSBuild/Language/Expressions/ExpressionParser.Conditions.cs
@@ -161,7 +161,7 @@ namespace MonoDevelop.MSBuild.Language.Expressions
 			int start = offset;
 
 			var ch = buffer[start];
-			if (ch == '.' || char.IsDigit (ch)) {
+			if (ch == '-' || ch == '.' || char.IsDigit (ch)) {
 				return ReadArgumentNumber (buffer, ref offset, endOffset, baseOffset, out hasError);
 			}
 

--- a/MonoDevelop.MSBuild/Language/Expressions/ExpressionParser.cs
+++ b/MonoDevelop.MSBuild/Language/Expressions/ExpressionParser.cs
@@ -642,7 +642,7 @@ namespace MonoDevelop.MSBuild.Language.Expressions
 					goto case '0';
 				case ',': case ')': case ']': case ' ': case '\r': case '\n':  case '\t':
 					return Result (ref offset, out hasError);
-				case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8': case '9':
+				case '-': case '0': case '1': case '2': case '3': case '4': case '5': case '6': case '7': case '8': case '9':
 					offset++;
 					continue;
 				default:


### PR DESCRIPTION
Hi, excellent project you've got here! I can't thank you enough, it's proving exceptionally useful, but I've run into a small bug I thought I should try to fix: conditions with negative numeric literals show an error despite working in MSBuild.

I'm using the IndexOf property function to find a character in a string, and then store its index in a property. When the character in question can't be found said function returns -1, and I check for that in a PropertyGroup condition later on:

```xml
<PropertyGroup Condition="$(MyPotentiallyNegativeProperty) > -1">
    <Foo>bar</Foo>
</PropertyGroup>
```

As of commit 8abab26ab34aa87b996164c07b7a223d7e4500bf this extension puts an error squiggle under the hyphen, reporting that it expects a right parenthesis, but the comparison works as expected in MSBuild.

Please excuse me if I've overstepped my bounds, but the changes required turned out to be rather simple, as far as I can tell, so I felt a pull request was justified. I'm not hugely confident that my addition of test cases to TestParseNoError is the best way to test for this, but after all the goal is ultimately to get those examples to parse without error. The new test cases fail before my changes but succeed afterwards, and all other tests continue to pass as well.

By all means let me know if I need to change anything, and thank you again for all your hard work!