### PR TITLE
Improve consistency/reliability of name comparisons

### DIFF
--- a/MonoDevelop.MSBuild.Editor/CodeFixes/RemovePropertyOrMetadataWithDefaultValueFixProvider.cs
+++ b/MonoDevelop.MSBuild.Editor/CodeFixes/RemovePropertyOrMetadataWithDefaultValueFixProvider.cs
@@ -22,7 +22,7 @@ namespace MonoDevelop.MSBuild.Editor.CodeFixes
 		public override Task RegisterCodeFixesAsync (MSBuildFixContext context)
 		{
 			foreach (var diag in context.Diagnostics) {
-				if (!(diag.Properties.TryGetValue ("Info", out var val) && val is VariableInfo info)) {
+				if (!(diag.Properties.TryGetValue (CoreDiagnosticProperty.Symbol, out var val) && val is VariableInfo info)) {
 					continue;
 				}
 

--- a/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
+++ b/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
@@ -274,7 +274,7 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 			return items;
 		}
 
-		static bool ItemIsInItemGroup (XElement itemEl) => itemEl.Parent is XElement parent && parent.NameEquals (MSBuildElementSyntax.ItemGroup.Name, true);
+		static bool ItemIsInItemGroup (XElement itemEl) => itemEl.Parent is XElement parent && parent.Name.Equals (MSBuildElementSyntax.ItemGroup.Name, true);
 
 		static XElement GetItemGroupItemFromMetadata (MSBuildResolveResult rr)
 			=> rr.ElementSyntax.SyntaxKind switch {

--- a/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
+++ b/MonoDevelop.MSBuild.Editor/Completion/MSBuildCompletionSource.cs
@@ -284,7 +284,7 @@ namespace MonoDevelop.MSBuild.Editor.Completion
 			};
 
 		static XAttribute GetIncludeOrUpdateAttribute (XElement item)
-			=> item.Attributes.FirstOrDefault (att => MSBuildElementSyntax.Item.GetAttribute (att.Name.FullName)?.SyntaxKind switch {
+			=> item.Attributes.FirstOrDefault (att => MSBuildElementSyntax.Item.GetAttribute (att)?.SyntaxKind switch {
 				MSBuildSyntaxKind.Item_Include => true,
 				MSBuildSyntaxKind.Item_Update => true,
 				_ => false

--- a/MonoDevelop.MSBuild.Editor/Refactorings/ExtractExpression/ExtractExpressionRefactoringProvider.cs
+++ b/MonoDevelop.MSBuild.Editor/Refactorings/ExtractExpression/ExtractExpressionRefactoringProvider.cs
@@ -120,10 +120,10 @@ partial class ExtractExpressionRefactoringProvider : MSBuildRefactoringProvider
 
 		// walk up the scopes in which propertygroups can exist
 		while (beforeElement?.ParentElement is XElement scope) {
-			if (scope.Name.FullName is not string fullName) {
+			if (scope.Name.HasPrefix || scope.Name.Name is not string name) {
 				yield break;
 			}
-			var syntax = MSBuildElementSyntax.Get (fullName);
+			var syntax = MSBuildElementSyntax.Get (name);
 			if (syntax.IsValidPropertyGroupScope ()) {
 				var elementsBeforeOffset = scope.ElementsBefore (beforeElement.Span.Start);
 				if (elementsBeforeOffset.OfSyntax (MSBuildElementSyntax.PropertyGroup).LastOrDefault (n => !n.HasCondition () && !n.IsSelfClosing && n.IsClosed) is XElement existingPg) {

--- a/MonoDevelop.MSBuild.Editor/Refactorings/MSBuildElementExtensions.cs
+++ b/MonoDevelop.MSBuild.Editor/Refactorings/MSBuildElementExtensions.cs
@@ -40,7 +40,7 @@ static class MSBuildElementExtensions
 	public static IEnumerable<XElement> OfSyntax (this IEnumerable<XElement> elements, MSBuildElementSyntax syntax)
 	{
 		foreach (var el in elements) {
-			if (el.NameEquals (syntax.Name, true)) {
+			if (el.Name.Equals (syntax.Name, true)) {
 				yield return el;
 			}
 		}

--- a/MonoDevelop.MSBuild.Editor/Refactorings/MSBuildElementExtensions.cs
+++ b/MonoDevelop.MSBuild.Editor/Refactorings/MSBuildElementExtensions.cs
@@ -14,7 +14,7 @@ static class MSBuildElementExtensions
 	/// <summary>
 	/// The <c>Condition</c> attribute, if any
 	/// </summary>
-	public static XAttribute? Condition (this XElement el) => el.Attributes.Get ("Condition", true);
+	public static XAttribute? Condition (this XElement el) => el.Attributes.Get (MSBuildAttributeName.Condition, true);
 
 	/// <summary>
 	/// Whether the element has a <c>Condition</c> attribute

--- a/MonoDevelop.MSBuild.Editor/Refactorings/SplitGroupRefactoringProvider.cs
+++ b/MonoDevelop.MSBuild.Editor/Refactorings/SplitGroupRefactoringProvider.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.MSBuild.Editor.Refactorings
 			}
 
 			//check name is cased correctly
-			var groupName = MSBuildElementSyntax.Get (group.Name.FullName)?.Name;
+			var groupName = MSBuildElementSyntax.Get (group)?.Name;
 
 			context.RegisterRefactoring (new SplitGroupAction (previousElement, groupName));
 

--- a/MonoDevelop.MSBuild.Editor/Refactorings/UseAttributesForMetadataRefactoringProvider.cs
+++ b/MonoDevelop.MSBuild.Editor/Refactorings/UseAttributesForMetadataRefactoringProvider.cs
@@ -55,14 +55,14 @@ namespace MonoDevelop.MSBuild.Editor.Refactorings
 
 			bool foundAny = false;
 
-			// we can only tranform the item if its only children are metadata elements without attributes
+			// we can only transform the item if its only children are metadata elements without attributes
 			foreach (var node in item.Nodes) {
-				if (!(node is XElement meta) || meta.Attributes.First != null) {
+				if (node is not XElement meta || meta.Attributes.First is not null || !meta.IsNamed || meta.Name.HasPrefix) {
 					return false;
 				}
 
 				// if the metadata element has a child, it must be a single text node
-				if (meta.FirstChild != null && (!(meta.FirstChild is XText t) || t.NextSibling != null)) {
+				if (meta.FirstChild != null && (meta.FirstChild is not XText t || t.NextSibling != null)) {
 					return false;
 				}
 

--- a/MonoDevelop.MSBuild.Editor/Refactorings/UseAttributesForMetadataRefactoringProvider.cs
+++ b/MonoDevelop.MSBuild.Editor/Refactorings/UseAttributesForMetadataRefactoringProvider.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.MSBuild.Editor.Refactorings
 			}
 
 			// check it isn't in an ItemDefinitionGroup
-			if (!(itemElement?.Parent is XElement pe && pe.Name.Equals ("ItemGroup", true))) {
+			if (!(itemElement?.Parent is XElement pe && pe.Name.Equals (MSBuildElementName.ItemGroup, true))) {
 				return Task.CompletedTask;
 			}
 

--- a/MonoDevelop.MSBuild.Editor/Refactorings/UseAttributesForMetadataRefactoringProvider.cs
+++ b/MonoDevelop.MSBuild.Editor/Refactorings/UseAttributesForMetadataRefactoringProvider.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.MSBuild.Editor.Refactorings
 			}
 
 			// check it isn't in an ItemDefinitionGroup
-			if (!(itemElement?.Parent is XElement pe && pe.NameEquals ("ItemGroup", true))) {
+			if (!(itemElement?.Parent is XElement pe && pe.Name.Equals ("ItemGroup", true))) {
 				return Task.CompletedTask;
 			}
 

--- a/MonoDevelop.MSBuild.Tests/Analyzers/CoreDiagnosticTests.cs
+++ b/MonoDevelop.MSBuild.Tests/Analyzers/CoreDiagnosticTests.cs
@@ -61,16 +61,15 @@ namespace MonoDevelop.MSBuild.Tests.Analyzers
 </PropertyGroup>
 </Project>";
 
-			var schema = new MSBuildSchema {
-				new PropertyInfo ("EnableFoo", "", MSBuildValueKind.Bool)
-			};
+			var enableFooProp = new PropertyInfo ("EnableFoo", "", MSBuildValueKind.Bool);
+			var schema = new MSBuildSchema { enableFooProp };
 
 			var expected = new MSBuildDiagnostic (
 				CoreDiagnostics.InvalidBool,
 				SpanFromLineColLength (source, 3, 15, 9),
 				ImmutableDictionary<string, object>.Empty
-					.Add ("Name", "bl&ah")
-					.Add ("ValueKind", MSBuildValueKind.Bool),
+					.Add (CoreDiagnosticProperty.MisspelledNameOrValue, "bl&ah")
+					.Add (CoreDiagnosticProperty.MisspelledValueExpectedType, enableFooProp),
 				messageArgs: ["bl&ah"]
 			);
 
@@ -154,18 +153,16 @@ namespace MonoDevelop.MSBuild.Tests.Analyzers
 					CoreDiagnostics.UnknownValue,
 					SpanFromLineColLength (source, 3, 23, 3),
 					ImmutableDictionary<string, object>.Empty
-						.Add ("Name", "Bye")
-						.Add ("ValueKind", MSBuildValueKind.CustomType)
-						.Add ("CustomType", customType),
+						.Add (CoreDiagnosticProperty.MisspelledNameOrValue, "Bye")
+						.Add (CoreDiagnosticProperty.MisspelledValueExpectedType, greetingsProp),
 					messageArgs: [ "Property", "Greetings", "Bye" ]
 				),
 				new MSBuildDiagnostic (
 					CoreDiagnostics.UnknownValue,
 					SpanFromLineColLength (source, 3, 33, 6),
 					ImmutableDictionary<string, object>.Empty
-						.Add ("Name", "See Ya")
-						.Add ("ValueKind", MSBuildValueKind.CustomType)
-						.Add ("CustomType", customType),
+						.Add (CoreDiagnosticProperty.MisspelledNameOrValue, "See Ya")
+						.Add (CoreDiagnosticProperty.MisspelledValueExpectedType, greetingsProp),
 					messageArgs: ["Property", "Greetings", "See Ya" ]
 				)
 			};
@@ -202,9 +199,8 @@ namespace MonoDevelop.MSBuild.Tests.Analyzers
 					CoreDiagnostics.UnknownValue,
 					SpanFromLineColLength (source, 3, 24, 3),
 					ImmutableDictionary<string, object>.Empty
-						.Add ("Name", "Bye")
-						.Add ("ValueKind", MSBuildValueKind.CustomType)
-						.Add ("CustomType", customType),
+						.Add (CoreDiagnosticProperty.MisspelledNameOrValue, "Bye")
+						.Add (CoreDiagnosticProperty.MisspelledValueExpectedType, greetingsProp),
 					messageArgs: [ "Property", "Greetings", "Bye" ]
 				),
 			};

--- a/MonoDevelop.MSBuild/Analyzers/RuntimeIdentifierOrRuntimeIdentifiersAnalyzer.cs
+++ b/MonoDevelop.MSBuild/Analyzers/RuntimeIdentifierOrRuntimeIdentifiersAnalyzer.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using MonoDevelop.MSBuild.Analysis;
 using MonoDevelop.MSBuild.Language;
 using MonoDevelop.MSBuild.Language.Expressions;
+using MonoDevelop.MSBuild.Language.Typesystem;
 
 namespace MonoDevelop.MSBuild.Analyzers
 {
@@ -62,7 +63,10 @@ namespace MonoDevelop.MSBuild.Analyzers
 			}
 		}
 
-		bool CoreDiagnosticFilter (MSBuildDiagnostic arg)
-			=> arg.Properties != null && arg.Properties.TryGetValue ("Name", out var value) && (string)value == "RuntimeIdentifier";
+		static bool CoreDiagnosticFilter (MSBuildDiagnostic arg) =>
+			arg.Properties is not null
+			&& arg.Properties.TryGetValue (CoreDiagnosticProperty.Symbol, out var value)
+			&& value is PropertyInfo pi
+			&& string.Equals (pi.Name, "RuntimeIdentifier", System.StringComparison.OrdinalIgnoreCase);
 	}
 }

--- a/MonoDevelop.MSBuild/Analyzers/TargetFrameworksOrTargetFrameworkAnalyzer.cs
+++ b/MonoDevelop.MSBuild/Analyzers/TargetFrameworksOrTargetFrameworkAnalyzer.cs
@@ -8,6 +8,7 @@ using MonoDevelop.MSBuild.Analysis;
 using MonoDevelop.MSBuild.Dom;
 using MonoDevelop.MSBuild.Language;
 using MonoDevelop.MSBuild.Language.Expressions;
+using MonoDevelop.MSBuild.Language.Typesystem;
 
 namespace MonoDevelop.MSBuild.Analyzers
 {
@@ -69,7 +70,10 @@ namespace MonoDevelop.MSBuild.Analyzers
 		static bool HasTargetFrameworksPropertyWithNonSingularValue (MSBuildPropertyGroupElement pg) =>
 			pg.PropertyElements.Any (p => p.IsElementNamed ("TargetFrameworks") && p.Value is not ExpressionText t);
 
-		bool CoreDiagnosticFilter (MSBuildDiagnostic arg)
-			=> arg.Properties != null && arg.Properties.TryGetValue ("Name", out var value) && (string)value == "TargetFramework";
+		static bool CoreDiagnosticFilter (MSBuildDiagnostic arg) =>
+			arg.Properties is not null
+			&& arg.Properties.TryGetValue(CoreDiagnosticProperty.Symbol, out var value)
+			&& value is PropertyInfo pi
+			&& string.Equals (pi.Name, "TargetFramework", System.StringComparison.OrdinalIgnoreCase);
 	}
 }

--- a/MonoDevelop.MSBuild/Dom/MSBuildAttribute.cs
+++ b/MonoDevelop.MSBuild/Dom/MSBuildAttribute.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+
 using MonoDevelop.MSBuild.Language.Expressions;
 using MonoDevelop.MSBuild.Language.Syntax;
 using MonoDevelop.Xml.Dom;
@@ -16,6 +18,7 @@ namespace MonoDevelop.MSBuild.Dom
 		{
 			XAttribute = xattribute;
 			Syntax = syntax;
+			Debug.Assert (xattribute.IsNamed && !xattribute.Name.HasPrefix);
 		}
 
 		public MSBuildAttributeSyntax Syntax { get; }
@@ -23,7 +26,7 @@ namespace MonoDevelop.MSBuild.Dom
 
 		public override MSBuildSyntaxKind SyntaxKind => Syntax.SyntaxKind;
 
-		public string Name => XAttribute.Name.FullName;
+		public string Name => XAttribute.Name.Name;
 
 		public bool IsNamed (string name) => string.Equals (Name, name, System.StringComparison.OrdinalIgnoreCase);
 	}

--- a/MonoDevelop.MSBuild/Dom/MSBuildElement.cs
+++ b/MonoDevelop.MSBuild/Dom/MSBuildElement.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 using MonoDevelop.MSBuild.Language.Expressions;
@@ -22,6 +23,7 @@ namespace MonoDevelop.MSBuild.Dom
 			: base (parent, value)
 		{
 			XElement = xelement;
+			Debug.Assert (xelement.IsNamed && !xelement.Name.HasPrefix);
 
 			MSBuildElement prevChild = null;
 			foreach (var childElement in xelement.Elements) {
@@ -43,7 +45,7 @@ namespace MonoDevelop.MSBuild.Dom
 
 			MSBuildAttribute prevAttribute = null;
 			foreach (var xatt in xelement.Attributes) {
-				if (xatt.Name.HasPrefix || Syntax.GetAttribute (xatt.Name.Name) is not MSBuildAttributeSyntax attributeSyntax) {
+				if (Syntax.GetAttribute (xatt) is not MSBuildAttributeSyntax attributeSyntax) {
 					continue;
 				}
 				ExpressionNode attributeValue = null;
@@ -70,7 +72,7 @@ namespace MonoDevelop.MSBuild.Dom
 		public abstract MSBuildElementSyntax Syntax { get; }
 		public XElement XElement { get; }
 
-		public string ElementName => XElement.Name.FullName;
+		public string ElementName => XElement.Name.Name;
 
 		public bool IsElementNamed (string name) => string.Equals (ElementName, name, StringComparison.OrdinalIgnoreCase);
 
@@ -124,7 +126,7 @@ namespace MonoDevelop.MSBuild.Dom
 		{
 			var element = firstChild;
 			while (element != null) {
-				if (string.Equals (element.XElement.Name.FullName, elementName, StringComparison.OrdinalIgnoreCase) && element is T typedElement) {
+				if (element.XElement.Name.Equals (elementName, true) && element is T typedElement) {
 					return typedElement;
 				}
 				element = element.nextSibling;

--- a/MonoDevelop.MSBuild/Dom/MSBuildElement.cs
+++ b/MonoDevelop.MSBuild/Dom/MSBuildElement.cs
@@ -25,44 +25,43 @@ namespace MonoDevelop.MSBuild.Dom
 
 			MSBuildElement prevChild = null;
 			foreach (var childElement in xelement.Elements) {
-				var childSyntax = Syntax.GetChild (childElement.Name.FullName);
-				if (childSyntax != null) {
-					ExpressionNode childValue = null;
-					if (childSyntax.ValueKind != MSBuildValueKind.Nothing && childElement.FirstChild is XText t) {
-						childValue = ExpressionParser.Parse (t.Text, ExpressionOptions.ItemsMetadataAndLists, t.Span.Start);
-					}
-					var child = CreateElement (childSyntax.SyntaxKind, this, childElement, childValue);
-					if (prevChild == null) {
-						firstChild = child;
-					} else {
-						prevChild.nextSibling = child;
-					}
-					prevChild = child;
+				if (childElement.Name.HasPrefix || Syntax.GetChild (childElement.Name.Name) is not MSBuildElementSyntax childSyntax) {
+					continue;
 				}
+				ExpressionNode childValue = null;
+				if (childSyntax.ValueKind != MSBuildValueKind.Nothing && childElement.FirstChild is XText t) {
+					childValue = ExpressionParser.Parse (t.Text, ExpressionOptions.ItemsMetadataAndLists, t.Span.Start);
+				}
+				var child = CreateElement (childSyntax.SyntaxKind, this, childElement, childValue);
+				if (prevChild == null) {
+					firstChild = child;
+				} else {
+					prevChild.nextSibling = child;
+				}
+				prevChild = child;
 			}
 
 			MSBuildAttribute prevAttribute = null;
 			foreach (var xatt in xelement.Attributes) {
-				var attributeSyntax = Syntax.GetAttribute (xatt.Name.FullName);
-				if (attributeSyntax != null) {
-
-					ExpressionNode attributeValue = null;
-					if (xatt.HasNonEmptyValue) {
-						if (attributeSyntax.ValueKind == MSBuildValueKind.Condition) {
-							attributeValue = ExpressionParser.ParseCondition (xatt.Value, xatt.ValueOffset.Value);
-						} else {
-							attributeValue = ExpressionParser.Parse (xatt.Value, ExpressionOptions.ItemsMetadataAndLists, xatt.ValueOffset.Value);
-						}
-					}
-
-					var attribute = new MSBuildAttribute (this, xatt, attributeSyntax, attributeValue);
-					if (prevAttribute == null) {
-						firstAttribute = attribute;
-					} else {
-						prevAttribute.nextSibling = attribute;
-					}
-					prevAttribute = attribute;
+				if (xatt.Name.HasPrefix || Syntax.GetAttribute (xatt.Name.Name) is not MSBuildAttributeSyntax attributeSyntax) {
+					continue;
 				}
+				ExpressionNode attributeValue = null;
+				if (xatt.HasNonEmptyValue) {
+					if (attributeSyntax.ValueKind == MSBuildValueKind.Condition) {
+						attributeValue = ExpressionParser.ParseCondition (xatt.Value, xatt.ValueOffset.Value);
+					} else {
+						attributeValue = ExpressionParser.Parse (xatt.Value, ExpressionOptions.ItemsMetadataAndLists, xatt.ValueOffset.Value);
+					}
+				}
+
+				var attribute = new MSBuildAttribute (this, xatt, attributeSyntax, attributeValue);
+				if (prevAttribute == null) {
+					firstAttribute = attribute;
+				} else {
+					prevAttribute.nextSibling = attribute;
+				}
+				prevAttribute = attribute;
 			}
 		}
 
@@ -267,7 +266,7 @@ namespace MonoDevelop.MSBuild.Dom
 		public MSBuildAttribute UpdateAttribute => GetAttribute (MSBuildSyntaxKind.Item_Update);
 		public MSBuildAttribute KeepMetadataAttribute => GetAttribute (MSBuildSyntaxKind.Item_KeepMetadata);
 		public MSBuildAttribute RemoveMetadataAttribute => GetAttribute (MSBuildSyntaxKind.Item_RemoveMetadata);
-		public MSBuildAttribute KeepDuplicatesAttribute => GetAttribute (MSBuildSyntaxKind.Parameter_Required);
+		public MSBuildAttribute KeepDuplicatesAttribute => GetAttribute (MSBuildSyntaxKind.Item_KeepDuplicates);
 
 		public IEnumerable<MSBuildAttribute> MetadataAttributes => GetAttributes (MSBuildSyntaxKind.Item_Metadata);
 

--- a/MonoDevelop.MSBuild/Language/CoreDiagnosticProperty.cs
+++ b/MonoDevelop.MSBuild/Language/CoreDiagnosticProperty.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MonoDevelop.MSBuild.Language
+{
+	/// <summary>
+	/// The names of properties used by various attached to core diagnostics.
+	/// </summary>
+	public static class CoreDiagnosticProperty
+	{
+		/// <summary>
+		/// A potentially misspelled name or value
+		/// </summary>
+		public const string MisspelledNameOrValue = nameof (MisspelledNameOrValue);
+
+		/// <summary>
+		/// For misspelled metadata, the name of the item
+		/// </summary>
+		public const string MisspelledMetadataItemName = nameof (MisspelledMetadataItemName);
+
+		/// <summary>
+		/// If a misspelled name has multiple spans to fix, the affected spans
+		/// </summary>
+		public const string MisspelledNameSpans = nameof (MisspelledNameSpans);
+
+		/// <summary>
+		/// For a potentially misspelled value, the symbol representing the expected type of the value
+		/// </summary>
+		public const string MisspelledValueExpectedType = nameof (MisspelledValueExpectedType);
+
+		/// <summary>
+		/// The symbol affected by the diagnostic
+		/// </summary>
+		public const string Symbol = nameof (Symbol);
+	}
+}

--- a/MonoDevelop.MSBuild/Language/CoreDiagnostics.cs
+++ b/MonoDevelop.MSBuild/Language/CoreDiagnostics.cs
@@ -369,14 +369,14 @@ namespace MonoDevelop.MSBuild.Language
 		public static readonly MSBuildDiagnosticDescriptor ImportVersionRequiresSdk = new (
 			ImportVersionRequiresSdk_Id,
 			"Import Version requires Sdk",
-			"Import may only have a Version attribute if it has an Sdk attribute",
+			"Import may only have a `Version` attribute if it has an `Sdk` attribute",
 			MSBuildDiagnosticSeverity.Error);
 
-		public const string ImportMinVersionRequiresSdk_Id = nameof(ImportMinVersionRequiresSdk);
-		public static readonly MSBuildDiagnosticDescriptor ImportMinVersionRequiresSdk = new (
-			ImportMinVersionRequiresSdk_Id,
-			"Import MinVersion requires Sdk",
-			"Import may only have a MinVersion attribute if it has an Sdk attribute",
+		public const string ImportMinimumVersionRequiresSdk_Id = nameof(ImportMinimumVersionRequiresSdk);
+		public static readonly MSBuildDiagnosticDescriptor ImportMinimumVersionRequiresSdk = new (
+			ImportMinimumVersionRequiresSdk_Id,
+			"Import `MinimumVersion` requires Sdk",
+			"Import may only have a `MinimumVersion` attribute if it has an `Sdk` attribute",
 			MSBuildDiagnosticSeverity.Warning);
 
 		public const string UnknownValue_Id = nameof(UnknownValue);

--- a/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using MonoDevelop.MSBuild.Analysis;
 using MonoDevelop.MSBuild.Dom;
 using MonoDevelop.MSBuild.Language.Expressions;
+using MonoDevelop.MSBuild.Language.Syntax;
 using MonoDevelop.MSBuild.Schema;
 using MonoDevelop.MSBuild.SdkResolution;
 using MonoDevelop.MSBuild.Workspace;
@@ -55,7 +56,7 @@ namespace MonoDevelop.MSBuild.Language
 
 		public void Build (XDocument doc, MSBuildParserContext context)
 		{
-			var project = doc.Nodes.OfType<XElement> ().FirstOrDefault (x => x.Name.Equals ("Project", true));
+			var project = doc.Nodes.OfType<XElement> ().FirstOrDefault (x => x.Name.Equals (MSBuildElementName.Project, true));
 			if (project == null) {
 				//TODO: error
 				return;

--- a/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocument.cs
@@ -55,7 +55,7 @@ namespace MonoDevelop.MSBuild.Language
 
 		public void Build (XDocument doc, MSBuildParserContext context)
 		{
-			var project = doc.Nodes.OfType<XElement> ().FirstOrDefault (x => x.NameEquals ("Project", true));
+			var project = doc.Nodes.OfType<XElement> ().FirstOrDefault (x => x.Name.Equals ("Project", true));
 			if (project == null) {
 				//TODO: error
 				return;

--- a/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
@@ -293,19 +293,17 @@ namespace MonoDevelop.MSBuild.Language
 				}
 
 				if (taskFactoryAtt is not null && taskFactoryAtt.TryGetValue (out var taskFactoryName) && taskFactoryName.Length > 0) {
-					switch (taskFactoryName.ToLowerInvariant ()) {
-					case "codetaskfactory":
-						if (string.Equals (asmFileAtt?.Value, "$(RoslynCodeTaskFactory)")) {
-							goto case "roslyncodetaskfactory";
-						}
-						break;
-					case "roslyncodetaskfactory":
+					switch (WellKnownTaskFactory.TryGet (taskFactoryName, asmFileAtt?.Value)) {
+					case WellKnownTaskFactory.RoslynCodeTaskFactory:
 						if (taskBody is not null) {
 							ValidateRoslynCodeTaskFactory (element, taskBody, parameterGroup);
 						}
 						break;
-					default:
+					case null:
 						Document.Diagnostics.Add (CoreDiagnostics.UnknownTaskFactory, taskFactoryAtt.ValueSpan.Value, taskFactoryName);
+						break;
+					default:
+						// known but we don't have any special handling
 						break;
 					}
 				}

--- a/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
@@ -415,7 +415,7 @@ namespace MonoDevelop.MSBuild.Language
 			}
 
 			foreach (var att in element.Attributes) {
-				if (!resolvedElement.GetAttribute (att.Name.Name).IsAbstract) {
+				if (!resolvedElement.GetAttribute (att)?.IsAbstract ?? false) {
 					continue;
 				}
 				if (!info.Parameters.TryGetValue (att.Name.Name, out TaskParameterInfo pi)) {

--- a/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocumentValidator.cs
@@ -206,7 +206,7 @@ namespace MonoDevelop.MSBuild.Language
 		void ValidateOnErrorOnlyFollowedByOnError (XElement element)
 		{
 			var nextSibling = element.GetNextSiblingElement ();
-			if (nextSibling != null && !nextSibling.NameEquals ("OnError", true)) {
+			if (nextSibling != null && !nextSibling.Name.Equals ("OnError", true)) {
 				Document.Diagnostics.Add (CoreDiagnostics.OnErrorMustBeLastInTarget, element.GetNextSiblingElement ().NameSpan);
 			}
 		}
@@ -222,7 +222,7 @@ namespace MonoDevelop.MSBuild.Language
 		{
 			bool foundItemOrPropertyName = false;
 			foreach (var att in element.Attributes) {
-				if (att.NameEquals ("ItemName", true) || att.NameEquals ("PropertyName", true)) {
+				if (att.Name.Equals ("ItemName", true) || att.Name.Equals ("PropertyName", true)) {
 					foundItemOrPropertyName = true;
 					break;
 				}
@@ -269,7 +269,7 @@ namespace MonoDevelop.MSBuild.Language
 
 			XElement parameterGroup = null, taskBody = null;
 			foreach (var child in element.Elements) {
-				if (child.NameEquals ("ParameterGroup", true)) {
+				if (child.Name.Equals ("ParameterGroup", true)) {
 					if (parameterGroup != null) {
 						Document.Diagnostics.Add (CoreDiagnostics.OneParameterGroup, child.NameSpan);
 					}
@@ -277,7 +277,7 @@ namespace MonoDevelop.MSBuild.Language
 						Document.Diagnostics.Add (CoreDiagnostics.OneTaskBody, child.NameSpan);
 					}
 					parameterGroup = child;
-				} else if (child.NameEquals ("Task", true)) {
+				} else if (child.Name.Equals ("Task", true)) {
 					taskBody = child;
 				}
 			}
@@ -357,10 +357,10 @@ namespace MonoDevelop.MSBuild.Language
 			}
 
 			foreach (var att in element.Attributes) {
-				if (att.NameEquals ("Version", true)) {
+				if (att.Name.Equals ("Version", true)) {
 					Document.Diagnostics.Add (CoreDiagnostics.ImportVersionRequiresSdk, att.NameSpan);
 				}
-				if (att.NameEquals ("MinVersion", true)) {
+				if (att.Name.Equals ("MinVersion", true)) {
 					Document.Diagnostics.Add (CoreDiagnostics.ImportMinVersionRequiresSdk, att.NameSpan);
 				}
 			}
@@ -371,15 +371,15 @@ namespace MonoDevelop.MSBuild.Language
 			bool isInTarget = resolved.IsInTarget (element);
 			bool hasInclude = false, hasUpdate = false, hasRemove = false;
 			foreach (var att in element.Attributes) {
-				hasInclude |= att.NameEquals ("Include", true);
-				hasRemove |= att.NameEquals ("Remove", true);
-				if (att.NameEquals ("Update", true)) {
+				hasInclude |= att.Name.Equals ("Include", true);
+				hasRemove |= att.Name.Equals ("Remove", true);
+				if (att.Name.Equals ("Update", true)) {
 					hasUpdate = true;
 					if (isInTarget) {
 						Document.Diagnostics.Add (CoreDiagnostics.ItemAttributeNotValidInTarget, att.NameSpan, att.Name.Name);
 					}
 				}
-				if (att.NameEquals ("KeepMetadata", true) || att.NameEquals ("RemoveMetadata", true) || att.NameEquals ("KeepDuplicates", true)) {
+				if (att.Name.Equals ("KeepMetadata", true) || att.Name.Equals ("RemoveMetadata", true) || att.Name.Equals ("KeepDuplicates", true)) {
 					if (!isInTarget) {
 						Document.Diagnostics.Add (CoreDiagnostics.ItemAttributeOnlyValidInTarget, att.NameSpan, att.Name.Name);
 					}
@@ -432,7 +432,7 @@ namespace MonoDevelop.MSBuild.Language
 			}
 
 			foreach (var child in element.Elements) {
-				if (child.NameEquals ("Output", true)) {
+				if (child.Name.Equals ("Output", true)) {
 					var paramNameAtt = child.Attributes.Get ("TaskParameter", true);
 					if (!paramNameAtt.TryGetValue (out string paramName) || paramName.Length == 0) {
 						continue;

--- a/MonoDevelop.MSBuild/Language/MSBuildDocumentVisitor.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildDocumentVisitor.cs
@@ -64,7 +64,7 @@ abstract class MSBuildDocumentVisitor
 		if (!element.Name.IsValid) {
 			return;
 		}
-		var resolved = MSBuildElementSyntax.Get (element.Name.Name, parent);
+		var resolved = MSBuildElementSyntax.Get (element, parent);
 		VisitResolvedElement (element, resolved);
 	}
 
@@ -119,9 +119,7 @@ abstract class MSBuildDocumentVisitor
 				continue;
 			}
 
-			var attributeSyntax = elementSyntax.GetAttribute (attributeName);
-
-			if (attributeSyntax is null) {
+			if (att.Name.HasPrefix || elementSyntax.GetAttribute (attributeName) is not MSBuildAttributeSyntax attributeSyntax) {
 				VisitUnknownAttribute (element, att);
 				continue;
 			}

--- a/MonoDevelop.MSBuild/Language/MSBuildNavigation.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildNavigation.cs
@@ -159,12 +159,12 @@ namespace MonoDevelop.MSBuild.Language
 			{
 				switch (elementSyntax.SyntaxKind) {
 				case MSBuildSyntaxKind.Import:
-					if (attribute.NameEquals ("Project", true)) {
+					if (attribute.Name.Equals ("Project", true)) {
 						CaptureAnnotations ();
 					}
 					break;
 				case MSBuildSyntaxKind.Project:
-					if (attribute.NameEquals ("Sdk", true)) {
+					if (attribute.Name.Equals ("Sdk", true)) {
 						CaptureAnnotations ();
 					}
 					break;

--- a/MonoDevelop.MSBuild/Language/MSBuildNavigation.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildNavigation.cs
@@ -157,23 +157,9 @@ namespace MonoDevelop.MSBuild.Language
 				MSBuildElementSyntax elementSyntax, MSBuildAttributeSyntax attributeSyntax,
 				ITypedSymbol elementSymbol, ITypedSymbol attributeSymbol)
 			{
-				switch (elementSyntax.SyntaxKind) {
-				case MSBuildSyntaxKind.Import:
-					if (attribute.Name.Equals ("Project", true)) {
-						CaptureAnnotations ();
-					}
-					break;
-				case MSBuildSyntaxKind.Project:
-					if (attribute.Name.Equals ("Sdk", true)) {
-						CaptureAnnotations ();
-					}
-					break;
-				}
-
-				base.VisitResolvedAttribute (element, attribute, elementSyntax, attributeSyntax, elementSymbol, attributeSymbol);
-
-				void CaptureAnnotations ()
-				{
+				switch (attributeSyntax.SyntaxKind) {
+				case MSBuildSyntaxKind.Project_Sdk:
+				case MSBuildSyntaxKind.Import_Project:
 					var annotations = Document.Annotations.GetMany<NavigationAnnotation> (attribute);
 					if (annotations != null) {
 						foreach (var group in annotations.GroupBy (a => a.Span.Start)) {
@@ -183,7 +169,10 @@ namespace MonoDevelop.MSBuild.Language
 							));
 						}
 					}
+					break;
 				}
+
+				base.VisitResolvedAttribute (element, attribute, elementSyntax, attributeSyntax, elementSymbol, attributeSymbol);
 			}
 
 			protected override void VisitValue (

--- a/MonoDevelop.MSBuild/Language/MSBuildReferenceCollector.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildReferenceCollector.cs
@@ -232,7 +232,7 @@ namespace MonoDevelop.MSBuild.Language
 				}
 				break;
 			case MSBuildSyntaxKind.UsingTask:
-				var nameAtt = element.Attributes.Get ("TaskName", true);
+				var nameAtt = element.Attributes.Get (MSBuildAttributeName.TaskName, true);
 				if (nameAtt is not null && nameAtt.TryGetNonEmptyValue (out var taskName)) {
 					var nameIdx = taskName.LastIndexOf ('.') + 1;
 					string name = nameIdx > 0 ? nameAtt.Value.Substring (nameIdx) : taskName;
@@ -277,7 +277,7 @@ namespace MonoDevelop.MSBuild.Language
 		internal static ExpressionNode? GetIncludeExpression (XElement itemElement)
 		{
 			var include = itemElement.Attributes
-				.FirstOrDefault (e => string.Equals (e.Name.Name, "Include", StringComparison.OrdinalIgnoreCase));
+				.FirstOrDefault (e => e.Name.Equals (MSBuildAttributeName.Include, true));
 
 			if (include == null || string.IsNullOrWhiteSpace (include.Value)) {
 				return null;
@@ -391,7 +391,7 @@ namespace MonoDevelop.MSBuild.Language
 		protected override void VisitResolvedElement (XElement element, MSBuildElementSyntax elementSyntax, ITypedSymbol elementSymbol)
 		{
 			if (elementSyntax.SyntaxKind == MSBuildSyntaxKind.Target) {
-				var nameAtt = element.Attributes.Get ("Name", true);
+				var nameAtt = element.Attributes.Get (MSBuildAttributeName.Name, true);
 				if (nameAtt != null && nameAtt.HasValue && IsMatch (nameAtt.Value)) {
 					AddResult (nameAtt.ValueSpan.Value, ReferenceUsage.Declaration);
 				}

--- a/MonoDevelop.MSBuild/Language/MSBuildResolver.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildResolver.cs
@@ -62,7 +62,7 @@ namespace MonoDevelop.MSBuild.Language
 				}
 
 				//code completion is forgiving, all we care about best guess resolve for deepest child
-				if (node is XElement xel && xel.Name.Prefix == null && xel.Name.Name is string elName) {
+				if (node is XElement xel && !xel.Name.HasPrefix && xel.Name.Name is string elName) {
 					el = xel;
 					languageElement = MSBuildElementSyntax.Get (elName, languageElement);
 					if (languageElement != null)

--- a/MonoDevelop.MSBuild/Language/MSBuildResolver.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildResolver.cs
@@ -164,7 +164,7 @@ namespace MonoDevelop.MSBuild.Language
 					rr.ReferenceKind = MSBuildReferenceKind.Task;
 					return;
 				case MSBuildSyntaxKind.Parameter:
-					var taskName = element.ParentElement!.ParentElement!.Attributes.Get ("TaskName", true)?.Value;
+					var taskName = element.ParentElement!.ParentElement!.Attributes.Get (MSBuildAttributeName.TaskName, true)?.Value;
 					if (!string.IsNullOrEmpty (taskName)) {
 						taskName = taskName.Substring (taskName.LastIndexOf ('.') + 1);
 						rr.ReferenceKind = MSBuildReferenceKind.TaskParameter;

--- a/MonoDevelop.MSBuild/Language/MSBuildRootDocument.cs
+++ b/MonoDevelop.MSBuild/Language/MSBuildRootDocument.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using MonoDevelop.MSBuild.Dom;
 using MonoDevelop.MSBuild.Evaluation;
 using MonoDevelop.MSBuild.Language.Expressions;
+using MonoDevelop.MSBuild.Language.Syntax;
 using MonoDevelop.MSBuild.Schema;
 using MonoDevelop.MSBuild.Workspace;
 using MonoDevelop.Xml.Dom;
@@ -268,13 +269,13 @@ namespace MonoDevelop.MSBuild.Language
 				}
 
 				if (XDocument.RootElement != null) {
-					var sdkAtt = XDocument.RootElement.Attributes["Sdk"];
+					var sdkAtt = XDocument.RootElement.Attributes.Get (MSBuildAttributeName.Sdk, true);
 					if (sdkAtt != null) {
 						toolsVersion = MSBuildToolsVersion.V15_0;
 						return toolsVersion.Value;
 					}
 
-					var tvAtt = XDocument.RootElement.Attributes["ToolsVersion"];
+					var tvAtt = XDocument.RootElement.Attributes.Get (MSBuildAttributeName.ToolsVersion, true);
 					if (tvAtt != null) {
 						var val = tvAtt.Value;
 						if (MSBuildToolsVersionExtensions.TryParse (val, out MSBuildToolsVersion tv)) {

--- a/MonoDevelop.MSBuild/Language/Syntax/MSBuildAttributeName.cs
+++ b/MonoDevelop.MSBuild/Language/Syntax/MSBuildAttributeName.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2014 Xamarin Inc.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MonoDevelop.MSBuild.Language.Syntax;
+
+/// <summary>
+/// Constant string representing all the MSBuild attribute names
+/// to help avoid typos and make intent clearer
+/// </summary>
+public static class MSBuildAttributeName
+{
+	public const string AfterTargets = "AfterTargets";
+	public const string Architecture = "Architecture";
+	public const string AssemblyFile = "AssemblyFile";
+	public const string AssemblyName = "AssemblyName";
+	public const string BeforeTargets = "BeforeTargets";
+	public const string Condition = "Condition";
+	public const string ContinueOnError = "ContinueOnError";
+	public const string DefaultTargets = "DefaultTargets";
+	public const string DependsOnTargets = "DependsOnTargets";
+	public const string Evaluate = "Evaluate";
+	public const string Exclude = "Exclude";
+	public const string ExecuteTargets = "ExecuteTargets";
+	public const string Include = "Include";
+	public const string InitialTargets = "InitialTargets";
+	public const string Inputs = "Inputs";
+	public const string ItemName = "ItemName";
+	public const string KeepDuplicateOutputs = "KeepDuplicateOutputs";
+	public const string KeepDuplicates = "KeepDuplicates";
+	public const string KeepMetadata = "KeepMetadata";
+	public const string Label = "Label";
+	public const string MinimumVersion = "MinimumVersion";
+	public const string Name = "Name";
+	public const string Output = "Output";
+	public const string Outputs = "Outputs";
+	public const string Parameter = "Parameter";
+	public const string ParameterType = "ParameterType";
+	public const string Project = "Project";
+	public const string PropertyName = "PropertyName";
+	public const string Remove = "Remove";
+	public const string RemoveMetadata = "RemoveMetadata";
+	public const string Required = "Required";
+	public const string Returns = "Returns";
+	public const string Runtime = "Runtime";
+	public const string Sdk = "Sdk";
+	public const string TaskFactory = "TaskFactory";
+	public const string TaskName = "TaskName";
+	public const string TaskParameter = "TaskParameter";
+	public const string ToolsVersion = "ToolsVersion";
+	public const string TreatAsLocalProperty = "TreatAsLocalProperty";
+	public const string Update = "Update";
+	public const string Version = "Version";
+	public const string xmlns = "xmlns";
+}

--- a/MonoDevelop.MSBuild/Language/Syntax/MSBuildElementName.cs
+++ b/MonoDevelop.MSBuild/Language/Syntax/MSBuildElementName.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MonoDevelop.MSBuild.Language.Syntax;
+
+/// <summary>
+/// Constant string representing all the MSBuild element names
+/// to help avoid typos and make intent clearer
+/// </summary>
+public static class MSBuildElementName
+{
+	public const string Choose = "Choose";
+	public const string Import = "Import";
+	public const string ImportGroup = "ImportGroup";
+	public const string ItemDefinition = "ItemDefinition";
+	public const string ItemDefinitionGroup = "ItemDefinitionGroup";
+	public const string ItemGroup = "ItemGroup";
+	public const string OnError = "OnError";
+	public const string Otherwise = "Otherwise";
+	public const string Output = "Output";
+	public const string ParameterGroup = "ParameterGroup";
+	public const string Project = "Project";
+	public const string ProjectExtensions = "ProjectExtensions";
+	public const string PropertyGroup = "PropertyGroup";
+	public const string Sdk = "Sdk";
+	public const string Target = "Target";
+	public const string Task = "Task";
+	public const string UsingTask = "UsingTask";
+	public const string When = "When";
+}

--- a/MonoDevelop.MSBuild/Language/Syntax/MSBuildElementSyntax.cs
+++ b/MonoDevelop.MSBuild/Language/Syntax/MSBuildElementSyntax.cs
@@ -11,10 +11,13 @@ using MonoDevelop.MSBuild.Language.Typesystem;
 using MonoDevelop.MSBuild.Schema;
 using MonoDevelop.Xml.Dom;
 
+using ElementName = MonoDevelop.MSBuild.Language.Syntax.MSBuildElementName;
+using AttributeName = MonoDevelop.MSBuild.Language.Syntax.MSBuildAttributeName;
+
 namespace MonoDevelop.MSBuild.Language.Syntax
 {
-	[DebuggerDisplay("MSBuildElementSyntax ({SyntaxKind,nq})")]
-	public class MSBuildElementSyntax : MSBuildSyntax
+	[DebuggerDisplay ("MSBuildElementSyntax ({SyntaxKind,nq})")]
+	public partial class MSBuildElementSyntax : MSBuildSyntax
 	{
 		MSBuildElementSyntax[] children = Array.Empty<MSBuildElementSyntax> ();
 		MSBuildAttributeSyntax[] attributes = Array.Empty<MSBuildAttributeSyntax> ();
@@ -54,7 +57,7 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 				return parent.GetChild (name);
 			}
 
-			builtin.TryGetValue (name, out MSBuildElementSyntax result);
+			allConcreteElements.TryGetValue (name, out MSBuildElementSyntax result);
 			return result;
 		}
 
@@ -66,7 +69,7 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 					if (n is XDocument) {
 						continue;
 					}
-					if (n is XElement xroot && xroot.Name.Equals ("Project", true)) {
+					if (n is XElement xroot && xroot.Name.Equals (ElementName.Project, true)) {
 						elementSyntax = Project;
 						continue;
 					}
@@ -95,7 +98,7 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 
 		public static MSBuildElementSyntax Get (XElement el)
 		{
-			if (el.Parent is XDocument && el.Name.Equals ("Project", true)) {
+			if (el.Parent is XDocument && el.Name.Equals (ElementName.Project, true)) {
 				return Project;
 			}
 			var parentSyntax = el.Parent is XElement p ? Get (p) : null;
@@ -154,13 +157,18 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 			return null;
 		}
 
-		static readonly Dictionary<string, MSBuildElementSyntax> builtin = new (StringComparer.OrdinalIgnoreCase);
+		static readonly Dictionary<string, MSBuildElementSyntax> allConcreteElements = new (StringComparer.OrdinalIgnoreCase);
 
-		static MSBuildElementSyntax AddBuiltin (string name, string description, MSBuildSyntaxKind kind, MSBuildValueKind valueKind = MSBuildValueKind.Nothing, bool isAbstract = false,
+		static MSBuildElementSyntax Create (string name, string description, MSBuildSyntaxKind kind, MSBuildValueKind valueKind = MSBuildValueKind.Nothing, bool isAbstract = false,
 			string? helpUrl = null, string? attributesHelpUrl = null)
 		{
 			var el = new MSBuildElementSyntax (name, description, kind, valueKind, isAbstract: isAbstract, helpUrl: helpUrl, attributesHelpUrl: attributesHelpUrl);
-			builtin.Add (el.Name, el);
+			if (name.Length != 0) {
+				Debug.Assert (!isAbstract);
+				allConcreteElements.Add (el.Name, el);
+			} else {
+				Debug.Assert (isAbstract);
+			}
 			return el;
 		}
 
@@ -191,29 +199,32 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 		// this is derived from Microsoft.Build.Core.xsd
 		static MSBuildElementSyntax ()
 		{
-			Choose = AddBuiltin ("Choose", ElementDescriptions.Choose, MSBuildSyntaxKind.Choose, helpUrl: HelpUrls.Element_Choose);
-			Import = AddBuiltin ("Import", ElementDescriptions.Import, MSBuildSyntaxKind.Import, helpUrl: HelpUrls.Element_Import, attributesHelpUrl: HelpUrls.Element_Import_Attributes);
-			ImportGroup = AddBuiltin ("ImportGroup", ElementDescriptions.ImportGroup, MSBuildSyntaxKind.ImportGroup, helpUrl: HelpUrls.Element_ImportGroup);
-			Item = AddBuiltin ("Item", ElementDescriptions.Item, MSBuildSyntaxKind.Item, isAbstract: true, helpUrl: HelpUrls.Element_Item, attributesHelpUrl: HelpUrls.Element_Item_Attributes);
-			ItemDefinition = AddBuiltin ("ItemDefinition", ElementDescriptions.ItemDefinition, MSBuildSyntaxKind.ItemDefinition, isAbstract: true); // docs don't treat this as distinct from Item in ItemGroup
-			ItemDefinitionGroup = AddBuiltin ("ItemDefinitionGroup", ElementDescriptions.ItemDefinitionGroup, MSBuildSyntaxKind.ItemDefinitionGroup, helpUrl: HelpUrls.Element_ItemDefinitionGroup);
-			ItemGroup = AddBuiltin ("ItemGroup", ElementDescriptions.ItemGroup, MSBuildSyntaxKind.ItemGroup, helpUrl: HelpUrls.Element_ItemGroup, attributesHelpUrl: HelpUrls.Element_ItemGroup_Attributes);
-			Metadata = AddBuiltin ("Metadata", ElementDescriptions.Metadata, MSBuildSyntaxKind.Metadata, MSBuildValueKind.Unknown, isAbstract: true, helpUrl: HelpUrls.Element_Metadata);
-			OnError = AddBuiltin ("OnError", ElementDescriptions.OnError, MSBuildSyntaxKind.OnError, helpUrl: HelpUrls.Element_OnError, attributesHelpUrl: HelpUrls.Element_OnError_Attributes);
-			Otherwise = AddBuiltin ("Otherwise", ElementDescriptions.Otherwise, MSBuildSyntaxKind.Otherwise, helpUrl: HelpUrls.Element_Otherwise);
-			Output = AddBuiltin ("Output", ElementDescriptions.Output, MSBuildSyntaxKind.Output, helpUrl: HelpUrls.Element_Output, attributesHelpUrl: HelpUrls.Element_Output_Attributes);
-			Parameter = AddBuiltin ("Parameter", ElementDescriptions.Parameter, MSBuildSyntaxKind.Parameter, isAbstract: true, helpUrl: HelpUrls.Element_Parameter, attributesHelpUrl: HelpUrls.Element_Parameter_Attributes);
-			ParameterGroup = AddBuiltin ("ParameterGroup", ElementDescriptions.ParameterGroup, MSBuildSyntaxKind.ParameterGroup, helpUrl: HelpUrls.Element_ParameterGroup);
-			Project = AddBuiltin ("Project", ElementDescriptions.Project, MSBuildSyntaxKind.Project, helpUrl: HelpUrls.Element_Project, attributesHelpUrl: HelpUrls.Element_Project_Attributes);
-			ProjectExtensions = AddBuiltin ("ProjectExtensions", ElementDescriptions.ProjectExtensions, MSBuildSyntaxKind.ProjectExtensions, MSBuildValueKind.Data, helpUrl: HelpUrls.Element_ProjectExtensions);
-			Property = AddBuiltin ("Property", ElementDescriptions.Property, MSBuildSyntaxKind.Property, MSBuildValueKind.Unknown, isAbstract: true, helpUrl: HelpUrls.Element_Property);
-			PropertyGroup = AddBuiltin ("PropertyGroup", ElementDescriptions.PropertyGroup, MSBuildSyntaxKind.PropertyGroup, helpUrl: HelpUrls.Element_PropertyGroup);
-			Sdk = AddBuiltin ("Sdk", ElementDescriptions.Sdk, MSBuildSyntaxKind.Sdk, helpUrl: HelpUrls.Element_Sdk, attributesHelpUrl: HelpUrls.Element_Sdk_Attributes);
-			Target = AddBuiltin ("Target", ElementDescriptions.Target, MSBuildSyntaxKind.Target, helpUrl: HelpUrls.Element_Target, attributesHelpUrl: HelpUrls.Element_Target_Attributes);
-			Task = AddBuiltin ("AbstractTask", ElementDescriptions.Task, MSBuildSyntaxKind.Task, isAbstract:true, helpUrl: HelpUrls.Element_Task, attributesHelpUrl: HelpUrls.Element_Task_Attributes);
-			TaskBody = AddBuiltin ("Task", ElementDescriptions.TaskBody, MSBuildSyntaxKind.TaskBody, helpUrl: HelpUrls.Element_TaskBody, attributesHelpUrl: HelpUrls.Element_TaskBody_Attributes);
-			UsingTask = AddBuiltin ("UsingTask", ElementDescriptions.UsingTask, MSBuildSyntaxKind.UsingTask, helpUrl: HelpUrls.Element_UsingTask, attributesHelpUrl: HelpUrls.Element_UsingTask_Attributes);
-			When = AddBuiltin ("When", ElementDescriptions.When, MSBuildSyntaxKind.When, helpUrl: HelpUrls.Element_When);
+			// note: abstract elements and attributes have "" for the name, as the actual name could be anything
+			const string ABSTRACT = "";
+
+			Choose = Create (ElementName.Choose, ElementDescriptions.Choose, MSBuildSyntaxKind.Choose, helpUrl: HelpUrls.Element_Choose);
+			Import = Create (ElementName.Import, ElementDescriptions.Import, MSBuildSyntaxKind.Import, helpUrl: HelpUrls.Element_Import, attributesHelpUrl: HelpUrls.Element_Import_Attributes);
+			ImportGroup = Create (ElementName.ImportGroup, ElementDescriptions.ImportGroup, MSBuildSyntaxKind.ImportGroup, helpUrl: HelpUrls.Element_ImportGroup);
+			Item = Create (ABSTRACT, ElementDescriptions.Item, MSBuildSyntaxKind.Item, isAbstract: true, helpUrl: HelpUrls.Element_Item, attributesHelpUrl: HelpUrls.Element_Item_Attributes);
+			ItemDefinition = Create (ABSTRACT, ElementDescriptions.ItemDefinition, MSBuildSyntaxKind.ItemDefinition, isAbstract: true); // docs don't treat this as distinct from Item in ItemGroup
+			ItemDefinitionGroup = Create (ElementName.ItemDefinitionGroup, ElementDescriptions.ItemDefinitionGroup, MSBuildSyntaxKind.ItemDefinitionGroup, helpUrl: HelpUrls.Element_ItemDefinitionGroup);
+			ItemGroup = Create (ElementName.ItemGroup, ElementDescriptions.ItemGroup, MSBuildSyntaxKind.ItemGroup, helpUrl: HelpUrls.Element_ItemGroup, attributesHelpUrl: HelpUrls.Element_ItemGroup_Attributes);
+			Metadata = Create (ABSTRACT, ElementDescriptions.Metadata, MSBuildSyntaxKind.Metadata, MSBuildValueKind.Unknown, isAbstract: true, helpUrl: HelpUrls.Element_Metadata);
+			OnError = Create (ElementName.OnError, ElementDescriptions.OnError, MSBuildSyntaxKind.OnError, helpUrl: HelpUrls.Element_OnError, attributesHelpUrl: HelpUrls.Element_OnError_Attributes);
+			Otherwise = Create (ElementName.Otherwise, ElementDescriptions.Otherwise, MSBuildSyntaxKind.Otherwise, helpUrl: HelpUrls.Element_Otherwise);
+			Output = Create (ElementName.Output, ElementDescriptions.Output, MSBuildSyntaxKind.Output, helpUrl: HelpUrls.Element_Output, attributesHelpUrl: HelpUrls.Element_Output_Attributes);
+			Parameter = Create (ABSTRACT, ElementDescriptions.Parameter, MSBuildSyntaxKind.Parameter, isAbstract: true, helpUrl: HelpUrls.Element_Parameter, attributesHelpUrl: HelpUrls.Element_Parameter_Attributes);
+			ParameterGroup = Create (ElementName.ParameterGroup, ElementDescriptions.ParameterGroup, MSBuildSyntaxKind.ParameterGroup, helpUrl: HelpUrls.Element_ParameterGroup);
+			Project = Create (ElementName.Project, ElementDescriptions.Project, MSBuildSyntaxKind.Project, helpUrl: HelpUrls.Element_Project, attributesHelpUrl: HelpUrls.Element_Project_Attributes);
+			ProjectExtensions = Create (ElementName.ProjectExtensions, ElementDescriptions.ProjectExtensions, MSBuildSyntaxKind.ProjectExtensions, MSBuildValueKind.Data, helpUrl: HelpUrls.Element_ProjectExtensions);
+			Property = Create (ABSTRACT, ElementDescriptions.Property, MSBuildSyntaxKind.Property, MSBuildValueKind.Unknown, isAbstract: true, helpUrl: HelpUrls.Element_Property);
+			PropertyGroup = Create (ElementName.PropertyGroup, ElementDescriptions.PropertyGroup, MSBuildSyntaxKind.PropertyGroup, helpUrl: HelpUrls.Element_PropertyGroup);
+			Sdk = Create (ElementName.Sdk, ElementDescriptions.Sdk, MSBuildSyntaxKind.Sdk, helpUrl: HelpUrls.Element_Sdk, attributesHelpUrl: HelpUrls.Element_Sdk_Attributes);
+			Target = Create (ElementName.Target, ElementDescriptions.Target, MSBuildSyntaxKind.Target, helpUrl: HelpUrls.Element_Target, attributesHelpUrl: HelpUrls.Element_Target_Attributes);
+			Task = Create (ABSTRACT, ElementDescriptions.Task, MSBuildSyntaxKind.Task, isAbstract: true, helpUrl: HelpUrls.Element_Task, attributesHelpUrl: HelpUrls.Element_Task_Attributes);
+			TaskBody = Create (ElementName.Task, ElementDescriptions.TaskBody, MSBuildSyntaxKind.TaskBody, helpUrl: HelpUrls.Element_TaskBody, attributesHelpUrl: HelpUrls.Element_TaskBody_Attributes);
+			UsingTask = Create (ElementName.UsingTask, ElementDescriptions.UsingTask, MSBuildSyntaxKind.UsingTask, helpUrl: HelpUrls.Element_UsingTask, attributesHelpUrl: HelpUrls.Element_UsingTask_Attributes);
+			When = Create (ElementName.When, ElementDescriptions.When, MSBuildSyntaxKind.When, helpUrl: HelpUrls.Element_When);
 
 			Choose.children = [Otherwise, When];
 			ImportGroup.children = [Import];
@@ -239,142 +250,142 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 			ParameterGroup.AbstractChild = Parameter;
 
 			Import.attributes = [
-				new (Import, "Project", ElementDescriptions.Import_Project, MSBuildSyntaxKind.Import_Project, MSBuildValueKind.ProjectFile, required: true),
-				new (Import, "Condition", ElementDescriptions.Import_Condition, MSBuildSyntaxKind.Import_Condition, MSBuildValueKind.Condition, helpUrl: HelpUrls.Attribute_Condition),
-				new (Import, "Label", ElementDescriptions.Import_Label, MSBuildSyntaxKind.Import_Label, MSBuildValueKind.Label),
-				new (Import, "Sdk", ElementDescriptions.Import_Sdk, MSBuildSyntaxKind.Import_Sdk, MSBuildValueKind.Sdk),
-				new (Import, "Version", ElementDescriptions.Import_Version, MSBuildSyntaxKind.Import_Version, MSBuildValueKind.SdkVersion),
-				new (Import, "MinimumVersion", ElementDescriptions.Import_MinimumVersion, MSBuildSyntaxKind.Import_MinimumVersion, MSBuildValueKind.SdkVersion),
+				new (Import, AttributeName.Project, ElementDescriptions.Import_Project, MSBuildSyntaxKind.Import_Project, MSBuildValueKind.ProjectFile, required: true),
+				new (Import, AttributeName.Condition, ElementDescriptions.Import_Condition, MSBuildSyntaxKind.Import_Condition, MSBuildValueKind.Condition, helpUrl: HelpUrls.Attribute_Condition),
+				new (Import, AttributeName.Label, ElementDescriptions.Import_Label, MSBuildSyntaxKind.Import_Label, MSBuildValueKind.Label),
+				new (Import, AttributeName.Sdk, ElementDescriptions.Import_Sdk, MSBuildSyntaxKind.Import_Sdk, MSBuildValueKind.Sdk),
+				new (Import, AttributeName.Version, ElementDescriptions.Import_Version, MSBuildSyntaxKind.Import_Version, MSBuildValueKind.SdkVersion),
+				new (Import, AttributeName.MinimumVersion, ElementDescriptions.Import_MinimumVersion, MSBuildSyntaxKind.Import_MinimumVersion, MSBuildValueKind.SdkVersion),
 			];
 
-			var itemMetadataAtt = new MSBuildAttributeSyntax (Item, "Metadata", ElementDescriptions.Metadata, MSBuildSyntaxKind.Item_Metadata, MSBuildValueKind.Unknown, abstractKind: MSBuildSyntaxKind.Metadata);
+			var itemMetadataAtt = new MSBuildAttributeSyntax (Item, ABSTRACT, ElementDescriptions.Metadata, MSBuildSyntaxKind.Item_Metadata, MSBuildValueKind.Unknown, abstractKind: MSBuildSyntaxKind.Metadata);
 			Item.AbstractAttribute = itemMetadataAtt;
 
 			Item.attributes = [
-				new (Item, "Exclude", ElementDescriptions.Item_Exclude, MSBuildSyntaxKind.Item_Exclude, MSBuildValueKind.MatchItem, helpUrl: HelpUrls.Attribute_Item_Include),
-				new (Item, "Include", ElementDescriptions.Item_Include, MSBuildSyntaxKind.Item_Include, MSBuildValueKind.MatchItem, helpUrl: HelpUrls.Attribute_Item_Exclude),
-				new (Item, "Remove", ElementDescriptions.Item_Remove, MSBuildSyntaxKind.Item_Remove, MSBuildValueKind.MatchItem),
-				new (Item, "Update", ElementDescriptions.Item_Update, MSBuildSyntaxKind.Item_Update, MSBuildValueKind.MatchItem),
-				new (Item, "Condition", ElementDescriptions.Item_Condition, MSBuildSyntaxKind.Item_Condition, MSBuildValueKind.Condition, helpUrl: HelpUrls.Attribute_Condition),
-				new (Item, "Label", ElementDescriptions.Item_Label, MSBuildSyntaxKind.Item_Label, MSBuildValueKind.Label),
-				new (Item, "KeepMetadata", ElementDescriptions.Item_KeepMetadata, MSBuildSyntaxKind.Item_KeepMetadata, MSBuildValueKind.MetadataName.AsList ()),
-				new (Item, "RemoveMetadata", ElementDescriptions.Item_RemoveMetadata, MSBuildSyntaxKind.Item_RemoveMetadata, MSBuildValueKind.MetadataName.AsList ()),
-				new (Item, "KeepDuplicates", ElementDescriptions.Item_KeepDuplicates, MSBuildSyntaxKind.Parameter_Required, MSBuildValueKind.Bool),
+				new (Item, AttributeName.Exclude, ElementDescriptions.Item_Exclude, MSBuildSyntaxKind.Item_Exclude, MSBuildValueKind.MatchItem, helpUrl: HelpUrls.Attribute_Item_Include),
+				new (Item, AttributeName.Include, ElementDescriptions.Item_Include, MSBuildSyntaxKind.Item_Include, MSBuildValueKind.MatchItem, helpUrl: HelpUrls.Attribute_Item_Exclude),
+				new (Item, AttributeName.Remove, ElementDescriptions.Item_Remove, MSBuildSyntaxKind.Item_Remove, MSBuildValueKind.MatchItem),
+				new (Item, AttributeName.Update, ElementDescriptions.Item_Update, MSBuildSyntaxKind.Item_Update, MSBuildValueKind.MatchItem),
+				new (Item, AttributeName.Condition, ElementDescriptions.Item_Condition, MSBuildSyntaxKind.Item_Condition, MSBuildValueKind.Condition, helpUrl: HelpUrls.Attribute_Condition),
+				new (Item, AttributeName.Label, ElementDescriptions.Item_Label, MSBuildSyntaxKind.Item_Label, MSBuildValueKind.Label),
+				new (Item, AttributeName.KeepMetadata, ElementDescriptions.Item_KeepMetadata, MSBuildSyntaxKind.Item_KeepMetadata, MSBuildValueKind.MetadataName.AsList ()),
+				new (Item, AttributeName.RemoveMetadata, ElementDescriptions.Item_RemoveMetadata, MSBuildSyntaxKind.Item_RemoveMetadata, MSBuildValueKind.MetadataName.AsList ()),
+				new (Item, AttributeName.KeepDuplicates, ElementDescriptions.Item_KeepDuplicates, MSBuildSyntaxKind.Item_KeepDuplicates, MSBuildValueKind.Bool),
 				itemMetadataAtt
 			];
 
 			Parameter.attributes = [
-				new (Parameter, "Output", ElementDescriptions.Parameter_Output, MSBuildSyntaxKind.Parameter_Output, MSBuildValueKind.Bool.AsLiteral()),
-				new (Parameter, "ParameterType", ElementDescriptions.Parameter_ParameterType, MSBuildSyntaxKind.Parameter_ParameterType, MSBuildValueKind.TaskParameterType),
-				new (Parameter, "Required", ElementDescriptions.Parameter_Required, MSBuildSyntaxKind.Parameter_Required, MSBuildValueKind.Bool.AsLiteral()),
+				new (Parameter, AttributeName.Output, ElementDescriptions.Parameter_Output, MSBuildSyntaxKind.Parameter_Output, MSBuildValueKind.Bool.AsLiteral()),
+				new (Parameter, AttributeName.ParameterType, ElementDescriptions.Parameter_ParameterType, MSBuildSyntaxKind.Parameter_ParameterType, MSBuildValueKind.TaskParameterType),
+				new (Parameter, AttributeName.Required, ElementDescriptions.Parameter_Required, MSBuildSyntaxKind.Parameter_Required, MSBuildValueKind.Bool.AsLiteral()),
 			];
 
 			Project.attributes = [
-				new (Project, "DefaultTargets", ElementDescriptions.Project_DefaultTargets, MSBuildSyntaxKind.Project_DefaultTargets, MSBuildValueKind.TargetName.AsList ().AsLiteral (),
+				new (Project, AttributeName.DefaultTargets, ElementDescriptions.Project_DefaultTargets, MSBuildSyntaxKind.Project_DefaultTargets, MSBuildValueKind.TargetName.AsList ().AsLiteral (),
 					helpUrl: "https://learn.microsoft.com/en-us/visualstudio/msbuild/target-build-order#default-targets"
 				),
-				new (Project, "InitialTargets", ElementDescriptions.Project_InitialTargets, MSBuildSyntaxKind.Project_InitialTargets, MSBuildValueKind.TargetName.AsList ().AsLiteral (),
+				new (Project, AttributeName.InitialTargets, ElementDescriptions.Project_InitialTargets, MSBuildSyntaxKind.Project_InitialTargets, MSBuildValueKind.TargetName.AsList ().AsLiteral (),
 					helpUrl: "https://learn.microsoft.com/en-us/visualstudio/msbuild/target-build-order#initial-targets"
 				),
-				new (Project, "ToolsVersion", ElementDescriptions.Project_ToolsVersion, MSBuildSyntaxKind.Project_ToolsVersion, MSBuildValueKind.ToolsVersion.AsLiteral (), versionInfo: MSBuildIntrinsics.ToolsVersionDeprecatedInfo, helpUrl: HelpUrls.Element_Project_ToolsVersion),
-				new (Project, "TreatAsLocalProperty", ElementDescriptions.Project_TreatAsLocalProperty, MSBuildSyntaxKind.Project_TreatAsLocalProperty, MSBuildValueKind.PropertyName.AsList ().AsLiteral ()),
-				new (Project, "xmlns", ElementDescriptions.Project_xmlns, MSBuildSyntaxKind.Project_xmlns, MSBuildValueKind.Xmlns.AsLiteral ()),
-				new (Project, "Sdk", ElementDescriptions.Project_Sdk, MSBuildSyntaxKind.Project_Sdk, MSBuildValueKind.SdkWithVersion.AsList().AsLiteral ()),
+				new (Project, AttributeName.ToolsVersion, ElementDescriptions.Project_ToolsVersion, MSBuildSyntaxKind.Project_ToolsVersion, MSBuildValueKind.ToolsVersion.AsLiteral (), versionInfo: MSBuildIntrinsics.ToolsVersionDeprecatedInfo, helpUrl: HelpUrls.Element_Project_ToolsVersion),
+				new (Project, AttributeName.TreatAsLocalProperty, ElementDescriptions.Project_TreatAsLocalProperty, MSBuildSyntaxKind.Project_TreatAsLocalProperty, MSBuildValueKind.PropertyName.AsList ().AsLiteral ()),
+				new (Project, AttributeName.xmlns, ElementDescriptions.Project_xmlns, MSBuildSyntaxKind.Project_xmlns, MSBuildValueKind.Xmlns.AsLiteral ()),
+				new (Project, AttributeName.Sdk, ElementDescriptions.Project_Sdk, MSBuildSyntaxKind.Project_Sdk, MSBuildValueKind.SdkWithVersion.AsList().AsLiteral ()),
 			];
 
 			Sdk.attributes = [
-				new (Project, "Name", ElementDescriptions.Sdk_Name, MSBuildSyntaxKind.Sdk_Name, MSBuildValueKind.Sdk, required: true),
-				new (Project, "Version", ElementDescriptions.Sdk_Version, MSBuildSyntaxKind.Sdk_Version, MSBuildValueKind.SdkVersion)
+				new (Project, AttributeName.Name, ElementDescriptions.Sdk_Name, MSBuildSyntaxKind.Sdk_Name, MSBuildValueKind.Sdk, required: true),
+				new (Project, AttributeName.Version, ElementDescriptions.Sdk_Version, MSBuildSyntaxKind.Sdk_Version, MSBuildValueKind.SdkVersion),
 			];
 
 			Target.attributes = [
-				new (Target, "Name", ElementDescriptions.Target_Name, MSBuildSyntaxKind.Target_Name, MSBuildValueKind.TargetName.AsLiteral (), required: true),
-				new (Target, "DependsOnTargets", ElementDescriptions.Target_DependsOnTargets, MSBuildSyntaxKind.Target_DependsOnTargets, MSBuildValueKind.TargetName.AsList (),
+				new (Target, AttributeName.Name, ElementDescriptions.Target_Name, MSBuildSyntaxKind.Target_Name, MSBuildValueKind.TargetName.AsLiteral (), required: true),
+				new (Target, AttributeName.DependsOnTargets, ElementDescriptions.Target_DependsOnTargets, MSBuildSyntaxKind.Target_DependsOnTargets, MSBuildValueKind.TargetName.AsList (),
 					helpUrl: "https://learn.microsoft.com/en-us/visualstudio/msbuild/target-build-order#target-dependencies"
 				),
-				new (Target, "Inputs", ElementDescriptions.Target_Inputs, MSBuildSyntaxKind.Target_Inputs, MSBuildValueKind.Unknown),
-				new (Target, "Outputs", ElementDescriptions.Target_Outputs, MSBuildSyntaxKind.Target_Outputs, MSBuildValueKind.Unknown),
-				new (Target, "Condition", ElementDescriptions.Target_Condition, MSBuildSyntaxKind.Target_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
-				new (Target, "KeepDuplicateOutputs", ElementDescriptions.Target_KeepDuplicateOutputs, MSBuildSyntaxKind.Target_KeepDuplicateOutputs, MSBuildValueKind.Bool),
-				new (Target, "Returns", ElementDescriptions.Target_Returns, MSBuildSyntaxKind.Target_Returns, MSBuildValueKind.Unknown),
-				new (Target, "BeforeTargets", ElementDescriptions.Target_BeforeTargets, MSBuildSyntaxKind.Target_BeforeTargets, MSBuildValueKind.TargetName.AsList (),
+				new (Target, AttributeName.Inputs, ElementDescriptions.Target_Inputs, MSBuildSyntaxKind.Target_Inputs, MSBuildValueKind.Unknown),
+				new (Target, AttributeName.Outputs, ElementDescriptions.Target_Outputs, MSBuildSyntaxKind.Target_Outputs, MSBuildValueKind.Unknown),
+				new (Target, AttributeName.Condition, ElementDescriptions.Target_Condition, MSBuildSyntaxKind.Target_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (Target, AttributeName.KeepDuplicateOutputs, ElementDescriptions.Target_KeepDuplicateOutputs, MSBuildSyntaxKind.Target_KeepDuplicateOutputs, MSBuildValueKind.Bool),
+				new (Target, AttributeName.Returns, ElementDescriptions.Target_Returns, MSBuildSyntaxKind.Target_Returns, MSBuildValueKind.Unknown),
+				new (Target, AttributeName.BeforeTargets, ElementDescriptions.Target_BeforeTargets, MSBuildSyntaxKind.Target_BeforeTargets, MSBuildValueKind.TargetName.AsList (),
 					helpUrl: "https://learn.microsoft.com/en-us/visualstudio/msbuild/target-build-order#beforetargets-and-aftertargets"
 				),
-				new (Target, "AfterTargets", ElementDescriptions.Target_AfterTargets, MSBuildSyntaxKind.Target_AfterTargets, MSBuildValueKind.TargetName.AsList (),
+				new (Target, AttributeName.AfterTargets, ElementDescriptions.Target_AfterTargets, MSBuildSyntaxKind.Target_AfterTargets, MSBuildValueKind.TargetName.AsList (),
 					helpUrl: "https://learn.microsoft.com/en-us/visualstudio/msbuild/target-build-order#beforetargets-and-aftertargets"
 				),
-				new (Target, "Label", ElementDescriptions.Target_Label, MSBuildSyntaxKind.Target_Label, MSBuildValueKind.Label),
+				new (Target, AttributeName.Label, ElementDescriptions.Target_Label, MSBuildSyntaxKind.Target_Label, MSBuildValueKind.Label),
 			];
 
 			Property.attributes = [
-				new (Property, "Label", ElementDescriptions.Property_Label, MSBuildSyntaxKind.Property_Label, MSBuildValueKind.Label),
-				new (Property, "Condition", ElementDescriptions.Property_Condition, MSBuildSyntaxKind.Property_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (Property, AttributeName.Label, ElementDescriptions.Property_Label, MSBuildSyntaxKind.Property_Label, MSBuildValueKind.Label),
+				new (Property, AttributeName.Condition, ElementDescriptions.Property_Condition, MSBuildSyntaxKind.Property_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
 			];
 
 			PropertyGroup.attributes = [
-				new (PropertyGroup, "Label", ElementDescriptions.PropertyGroup_Label, MSBuildSyntaxKind.PropertyGroup_Label, MSBuildValueKind.Label),
-				new (PropertyGroup, "Condition", ElementDescriptions.PropertyGroup_Condition, MSBuildSyntaxKind.PropertyGroup_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (PropertyGroup, AttributeName.Label, ElementDescriptions.PropertyGroup_Label, MSBuildSyntaxKind.PropertyGroup_Label, MSBuildValueKind.Label),
+				new (PropertyGroup, AttributeName.Condition, ElementDescriptions.PropertyGroup_Condition, MSBuildSyntaxKind.PropertyGroup_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
 			];
 
 			ImportGroup.attributes = [
-				new (ImportGroup, "Label", ElementDescriptions.ImportGroup_Label, MSBuildSyntaxKind.ImportGroup_Label, MSBuildValueKind.Label),
-				new (ImportGroup, "Condition", ElementDescriptions.ImportGroup_Condition, MSBuildSyntaxKind.ImportGroup_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (ImportGroup, AttributeName.Label, ElementDescriptions.ImportGroup_Label, MSBuildSyntaxKind.ImportGroup_Label, MSBuildValueKind.Label),
+				new (ImportGroup, AttributeName.Condition, ElementDescriptions.ImportGroup_Condition, MSBuildSyntaxKind.ImportGroup_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
 			];
 
 			ItemGroup.attributes = [
-				new (ItemGroup, "Label", ElementDescriptions.ItemGroup_Label, MSBuildSyntaxKind.ItemGroup_Label, MSBuildValueKind.Label),
-				new (ItemGroup, "Condition", ElementDescriptions.ItemGroup_Condition, MSBuildSyntaxKind.ItemGroup_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (ItemGroup, AttributeName.Label, ElementDescriptions.ItemGroup_Label, MSBuildSyntaxKind.ItemGroup_Label, MSBuildValueKind.Label),
+				new (ItemGroup, AttributeName.Condition, ElementDescriptions.ItemGroup_Condition, MSBuildSyntaxKind.ItemGroup_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
 			];
 
 			ItemDefinitionGroup.attributes = [
-				new (ItemDefinitionGroup, "Label", ElementDescriptions.ItemDefinitionGroup_Label, MSBuildSyntaxKind.ItemDefinitionGroup_Label, MSBuildValueKind.Label),
-				new (ItemDefinitionGroup, "Condition", ElementDescriptions.ItemDefinitionGroup_Condition, MSBuildSyntaxKind.ItemDefinitionGroup_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (ItemDefinitionGroup, AttributeName.Label, ElementDescriptions.ItemDefinitionGroup_Label, MSBuildSyntaxKind.ItemDefinitionGroup_Label, MSBuildValueKind.Label),
+				new (ItemDefinitionGroup, AttributeName.Condition, ElementDescriptions.ItemDefinitionGroup_Condition, MSBuildSyntaxKind.ItemDefinitionGroup_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
 			];
 
 			When.attributes = [
-				new (When, "Condition", ElementDescriptions.When_Condition, MSBuildSyntaxKind.When_Condition, MSBuildValueKind.Condition, required : true, helpUrl: HelpUrls.Attribute_Condition),
+				new (When, AttributeName.Condition, ElementDescriptions.When_Condition, MSBuildSyntaxKind.When_Condition, MSBuildValueKind.Condition, required : true, helpUrl: HelpUrls.Attribute_Condition),
 			];
 
 			OnError.attributes = [
-				new (OnError, "ExecuteTargets", ElementDescriptions.OnError_ExecuteTargets, MSBuildSyntaxKind.OnError_ExecuteTargets, MSBuildValueKind.TargetName.AsList (), required : true),
-				new (OnError, "Condition", ElementDescriptions.OnError_Condition, MSBuildSyntaxKind.OnError_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
-				new (OnError, "Label", ElementDescriptions.OnError_Label, MSBuildSyntaxKind.OnError_Label, MSBuildValueKind.Label),
+				new (OnError, AttributeName.ExecuteTargets, ElementDescriptions.OnError_ExecuteTargets, MSBuildSyntaxKind.OnError_ExecuteTargets, MSBuildValueKind.TargetName.AsList (), required : true),
+				new (OnError, AttributeName.Condition, ElementDescriptions.OnError_Condition, MSBuildSyntaxKind.OnError_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (OnError, AttributeName.Label, ElementDescriptions.OnError_Label, MSBuildSyntaxKind.OnError_Label, MSBuildValueKind.Label),
 			];
 
 			UsingTask.attributes = [
-				new (UsingTask, "Condition", ElementDescriptions.UsingTask_Condition, MSBuildSyntaxKind.UsingTask_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
-				new (UsingTask, "AssemblyName", ElementDescriptions.UsingTask_AssemblyName, MSBuildSyntaxKind.UsingTask_AssemblyName, MSBuildValueKind.TaskAssemblyName),
-				new (UsingTask, "AssemblyFile", ElementDescriptions.UsingTask_AssemblyFile, MSBuildSyntaxKind.UsingTask_AssemblyFile, MSBuildValueKind.TaskAssemblyFile),
-				new (UsingTask, "TaskName", ElementDescriptions.UsingTask_TaskName, MSBuildSyntaxKind.UsingTask_TaskName, MSBuildValueKind.TaskName, required: true),
-				new (UsingTask, "TaskFactory", ElementDescriptions.UsingTask_TaskFactory, MSBuildSyntaxKind.UsingTask_TaskFactory, MSBuildValueKind.TaskFactory),
-				new (UsingTask, "Architecture", ElementDescriptions.UsingTask_Architecture, MSBuildSyntaxKind.UsingTask_Architecture, MSBuildValueKind.TaskArchitecture),
-				new (UsingTask, "Runtime", ElementDescriptions.UsingTask_Runtime, MSBuildSyntaxKind.UsingTask_Runtime, MSBuildValueKind.TaskRuntime),
+				new (UsingTask, AttributeName.Condition, ElementDescriptions.UsingTask_Condition, MSBuildSyntaxKind.UsingTask_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (UsingTask, AttributeName.AssemblyName, ElementDescriptions.UsingTask_AssemblyName, MSBuildSyntaxKind.UsingTask_AssemblyName, MSBuildValueKind.TaskAssemblyName),
+				new (UsingTask, AttributeName.AssemblyFile, ElementDescriptions.UsingTask_AssemblyFile, MSBuildSyntaxKind.UsingTask_AssemblyFile, MSBuildValueKind.TaskAssemblyFile),
+				new (UsingTask, AttributeName.TaskName, ElementDescriptions.UsingTask_TaskName, MSBuildSyntaxKind.UsingTask_TaskName, MSBuildValueKind.TaskName, required: true),
+				new (UsingTask, AttributeName.TaskFactory, ElementDescriptions.UsingTask_TaskFactory, MSBuildSyntaxKind.UsingTask_TaskFactory, MSBuildValueKind.TaskFactory),
+				new (UsingTask, AttributeName.Architecture, ElementDescriptions.UsingTask_Architecture, MSBuildSyntaxKind.UsingTask_Architecture, MSBuildValueKind.TaskArchitecture),
+				new (UsingTask, AttributeName.Runtime, ElementDescriptions.UsingTask_Runtime, MSBuildSyntaxKind.UsingTask_Runtime, MSBuildValueKind.TaskRuntime),
 			];
 
 			TaskBody.attributes = [
-				new (TaskBody, "Evaluate", ElementDescriptions.UsingTaskBody_Evaluate, MSBuildSyntaxKind.UsingTaskBody_Evaluate, MSBuildValueKind.Bool.AsLiteral ()),
+				new (TaskBody, AttributeName.Evaluate, ElementDescriptions.UsingTaskBody_Evaluate, MSBuildSyntaxKind.UsingTaskBody_Evaluate, MSBuildValueKind.Bool.AsLiteral ()),
 			];
 
 			Output.attributes = [
-				new (Output, "TaskParameter", ElementDescriptions.Output_TaskParameter, MSBuildSyntaxKind.Output_TaskParameter, MSBuildValueKind.TaskOutputParameterName.AsLiteral (), required : true),
-				new (Output, "Condition", ElementDescriptions.Output_Condition, MSBuildSyntaxKind.Output_Condition,  MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
-				new (Output, "ItemName", ElementDescriptions.Output_ItemName, MSBuildSyntaxKind.Output_ItemName, MSBuildValueKind.ItemName.AsLiteral ()),
-				new (Output, "PropertyName", ElementDescriptions.Output_PropertyName, MSBuildSyntaxKind.Output_PropertyName, MSBuildValueKind.PropertyName.AsLiteral ()),
+				new (Output, AttributeName.TaskParameter, ElementDescriptions.Output_TaskParameter, MSBuildSyntaxKind.Output_TaskParameter, MSBuildValueKind.TaskOutputParameterName.AsLiteral (), required : true),
+				new (Output, AttributeName.Condition, ElementDescriptions.Output_Condition, MSBuildSyntaxKind.Output_Condition,  MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (Output, AttributeName.ItemName, ElementDescriptions.Output_ItemName, MSBuildSyntaxKind.Output_ItemName, MSBuildValueKind.ItemName.AsLiteral ()),
+				new (Output, AttributeName.PropertyName, ElementDescriptions.Output_PropertyName, MSBuildSyntaxKind.Output_PropertyName, MSBuildValueKind.PropertyName.AsLiteral ()),
 			];
 
-			var taskParameterAtt = new MSBuildAttributeSyntax (Task, "Parameter", ElementDescriptions.Task_Parameter, MSBuildSyntaxKind.Task_Parameter, MSBuildValueKind.Unknown, abstractKind: MSBuildSyntaxKind.Parameter);
+			var taskParameterAtt = new MSBuildAttributeSyntax (Task, ABSTRACT, ElementDescriptions.Task_Parameter, MSBuildSyntaxKind.Task_Parameter, MSBuildValueKind.Unknown, abstractKind: MSBuildSyntaxKind.Parameter);
 			Task.AbstractAttribute = taskParameterAtt;
 
 			Task.attributes = [
-				new (Task, "Condition", ElementDescriptions.Task_Condition, MSBuildSyntaxKind.Task_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
-				new (Task, "ContinueOnError", ElementDescriptions.Task_ContinueOnError, MSBuildSyntaxKind.Task_ContinueOnError, MSBuildValueKind.ContinueOnError),
-				new (Task, "Architecture", ElementDescriptions.Task_Architecture, MSBuildSyntaxKind.Task_Architecture, MSBuildValueKind.TaskArchitecture),
-				new (Task, "Runtime", ElementDescriptions.Task_Runtime, MSBuildSyntaxKind.Task_Runtime, MSBuildValueKind.TaskRuntime),
+				new (Task, AttributeName.Condition, ElementDescriptions.Task_Condition, MSBuildSyntaxKind.Task_Condition, MSBuildValueKind.Condition, helpUrl : HelpUrls.Attribute_Condition),
+				new (Task, AttributeName.ContinueOnError, ElementDescriptions.Task_ContinueOnError, MSBuildSyntaxKind.Task_ContinueOnError, MSBuildValueKind.ContinueOnError),
+				new (Task, AttributeName.Architecture, ElementDescriptions.Task_Architecture, MSBuildSyntaxKind.Task_Architecture, MSBuildValueKind.TaskArchitecture),
+				new (Task, AttributeName.Runtime, ElementDescriptions.Task_Runtime, MSBuildSyntaxKind.Task_Runtime, MSBuildValueKind.TaskRuntime),
 				taskParameterAtt
 			];
 
 			Metadata.attributes = [
-				new (Metadata, "Condition", ElementDescriptions.Metadata_Condition, MSBuildSyntaxKind.Metadata_Condition, MSBuildValueKind.Condition, helpUrl: HelpUrls.Attribute_Condition),
+				new (Metadata, AttributeName.Condition, ElementDescriptions.Metadata_Condition, MSBuildSyntaxKind.Metadata_Condition, MSBuildValueKind.Condition, helpUrl: HelpUrls.Attribute_Condition),
 			];
 		}
 	}

--- a/MonoDevelop.MSBuild/Language/Syntax/MSBuildElementSyntax.cs
+++ b/MonoDevelop.MSBuild/Language/Syntax/MSBuildElementSyntax.cs
@@ -66,7 +66,7 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 					if (n is XDocument) {
 						continue;
 					}
-					if (n is XElement xroot && xroot.NameEquals ("Project", true)) {
+					if (n is XElement xroot && xroot.Name.Equals ("Project", true)) {
 						elementSyntax = Project;
 						continue;
 					}
@@ -95,7 +95,7 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 
 		public static MSBuildElementSyntax Get (XElement el)
 		{
-			if (el.Parent is XDocument && el.NameEquals (Project.Name, true)) {
+			if (el.Parent is XDocument && el.Name.Equals ("Project", true)) {
 				return Project;
 			}
 			var parentSyntax = el.Parent is XElement p ? Get (p) : null;

--- a/MonoDevelop.MSBuild/Language/Syntax/MSBuildSyntaxKind.cs
+++ b/MonoDevelop.MSBuild/Language/Syntax/MSBuildSyntaxKind.cs
@@ -63,6 +63,7 @@ namespace MonoDevelop.MSBuild.Language.Syntax
 		Item_Update         = Item + (7 << 16),
 		Item_KeepMetadata   = Item + (8 << 16),
 		Item_RemoveMetadata = Item + (9 << 16),
+		Item_KeepDuplicates = Item + (10 << 16),
 
 		Parameter_Required      = Parameter + (3 << 16),
 		Parameter_Output        = Parameter + (4 << 16),

--- a/MonoDevelop.MSBuild/Language/WellKnownTaskFactory.cs
+++ b/MonoDevelop.MSBuild/Language/WellKnownTaskFactory.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace MonoDevelop.MSBuild.Language;
+
+class WellKnownTaskFactory
+{
+	const string RoslynCodeTaskFactoryAssemblyProperty = "$(RoslynCodeTaskFactory)";
+
+	public const string CodeTaskFactory = "CodeTaskFactory";
+	public const string RoslynCodeTaskFactory = "RoslynCodeTaskFactory";
+
+	public static string? TryGet (string taskFactoryAttributeValue, string? assemblyNameAttributeValue)
+	{
+		if (string.IsNullOrEmpty (taskFactoryAttributeValue)) {
+			throw new ArgumentException ($"'{nameof (taskFactoryAttributeValue)}' cannot be null or empty.", nameof (taskFactoryAttributeValue));
+		}
+
+		if (string.Equals (taskFactoryAttributeValue, CodeTaskFactory, StringComparison.OrdinalIgnoreCase)) {
+			if (string.Equals (assemblyNameAttributeValue, RoslynCodeTaskFactoryAssemblyProperty, StringComparison.OrdinalIgnoreCase)) {
+				return RoslynCodeTaskFactory;
+			}
+			return CodeTaskFactory;
+		}
+
+		if (string.Equals (taskFactoryAttributeValue, RoslynCodeTaskFactory, StringComparison.OrdinalIgnoreCase)) {
+			return RoslynCodeTaskFactory;
+		}
+
+		return null;
+	}
+}

--- a/MonoDevelop.MSBuild/Schema/MSBuildCompletionExtensions.cs
+++ b/MonoDevelop.MSBuild/Schema/MSBuildCompletionExtensions.cs
@@ -37,11 +37,14 @@ namespace MonoDevelop.MSBuild.Schema
 				if (!spat.IsAbstract) {
 					if (rr.ElementSyntax.SyntaxKind == MSBuildSyntaxKind.Item) {
 						if (isInTarget) {
-							if (spat.Name == "Update") {
+							if (spat.SyntaxKind == MSBuildSyntaxKind.Item_Update) {
 								continue;
 							}
 						} else {
-							if (spat.Name == "KeepMetadata" || spat.Name == "RemoveMetadata" || spat.Name == "KeepDuplicates") {
+							switch (spat.SyntaxKind) {
+							case MSBuildSyntaxKind.Item_KeepMetadata:
+							case MSBuildSyntaxKind.Item_RemoveMetadata:
+							case MSBuildSyntaxKind.Item_KeepDuplicates:
 								continue;
 							}
 						}
@@ -251,7 +254,7 @@ namespace MonoDevelop.MSBuild.Schema
 
 			if (rr.AttributeSyntax?.SyntaxKind == MSBuildSyntaxKind.Import_Project && rr.Element != null) {
 
-				var sdkAtt = rr.Element.Attributes.Get ("Sdk", true)?.Value;
+				var sdkAtt = rr.Element.Attributes.Get (MSBuildAttributeName.Sdk, true)?.Value;
 				if (string.IsNullOrEmpty (sdkAtt) || !Microsoft.Build.Framework.SdkReference.TryParse (sdkAtt, out var sdkRef)) {
 					// if there's an invalid SDK attribute, don't try to provide path completion, it'll be wrong
 					return null;

--- a/MonoDevelop.MSBuild/Schema/MSBuildCompletionExtensions.cs
+++ b/MonoDevelop.MSBuild/Schema/MSBuildCompletionExtensions.cs
@@ -80,7 +80,7 @@ namespace MonoDevelop.MSBuild.Schema
 				goto case MSBuildSyntaxKind.ItemGroup;
 			case MSBuildSyntaxKind.ItemGroup:
 			case MSBuildSyntaxKind.PropertyGroup:
-				if (element.ParentElement is XElement te && te.NameEquals (MSBuildElementSyntax.Target.Name, true)) {
+				if (element.ParentElement is XElement te && te.Name.Equals (MSBuildElementSyntax.Target.Name, true)) {
 					targetElement = te;
 					return true;
 				}


### PR DESCRIPTION
* Update MD.Xml for updated XName comparison APIs
* Use new XName comparison APIs
* Define and consistently use constants for element name, attribute names, diagnostic property names, and taskfactory names
* Improve various name comparison checks to be more accurate